### PR TITLE
Revert "Set up nimble to more easily build the library."

### DIFF
--- a/nimgraphviz.nimble
+++ b/nimgraphviz.nimble
@@ -5,10 +5,6 @@ author        = "Quinn Freedman"
 description   = "Nim bindings for the GraphViz tool and the DOT graph language"
 license       = "MIT"
 srcDir        = "src"
-when system.hostOS == "windows":
-  bin           = @["nimgraphviz.exe"]
-else:
-  bin           = @["nimgraphviz"]
 
 # Dependencies
 


### PR DESCRIPTION
It looks like providing binaries in nimgraphviz.nimble made developing easier, but breaks something when distributing the library…
I can't build projects that depend on nimgraphviz v0.2 anymore. So I just reverted the changes I made, unless there is a better way ??
Anyway, I apologize for any inconvenience…

> Turns out it was useful when developin the library, not when using it...
> 
> This reverts (most of) commit 1a87d33288b7b185beef199b0f958293ef5f7f04.