### PR TITLE
Rewrite the bulk of the code to improve security, enhanced subgraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,27 @@ Read the docs [here](https://quinnfreedman.github.io/nimgraphviz/).
 Here is an example of creating a simple graph:
 
 ```nim
-# create a directed graph
-var graph = newGraph(directed=true)
+let main = newGraph() # create a graph (strict, but not oriented)
+let sub = newSubGraph(main) # the graph can have subgraph
+# the subgraph can have subgraphs too!
 
-# set some attributes of the graph:
-graph.graphAttr.add("fontsize", "32")
-graph.graphAttr.add("label", "Test Graph")
+# adding an edge, along with attributes
+main.addEdge("a"--"b", ("label", "A to B"))
 
-# add edges:
-# (if a node does not exist already it will be created automatically)
-graph.addEdge("a", "b", "a-to-b", [("label", "A to B")])
-graph.addEdge("c", "b", "c-to-b", [("style", "dotted")])
-graph.addEdge("b", "a", "b-to-a")
-graph.addNode("c", [("color", "blue"), ("shape", "box"),
-                        ("style", "filled"), ("fontcolor", "white")])
-graph.addNode("d", [("lable", "node")])
+# attributes can also be added afterwards
+sub.addEdge("b"--"c")
+sub["b"--"c"]["style"] = "dotted"
+
+# similar features are available for nodes
+main["d"]["label"] = "This node stands alone"
+
+# subgraphs whose name begin in "cluster" have a special meaning in DOT.
+sub.name = "cluster_whatever"
+sub["bgcolor"] = "grey" # hey, graph attributes can be set as well!
 
 # if you want to export the graph in the DOT language,
 # you can do it like this:
-# echo graph.exportDot()
+echo main.exportDot()
 
 # Export graph as PNG:
 graph.exportImage("test_graph.png")

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,13 +10,14 @@
 
 <!-- Favicon -->
 <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AAAAAAUAAAAF////AP///wD///8A////AP///wD///8A////AP///wD///8A////AAAAAAIAAABbAAAAlQAAAKIAAACbAAAAmwAAAKIAAACVAAAAWwAAAAL///8A////AP///wD///8A////AAAAABQAAADAAAAAYwAAAA3///8A////AP///wD///8AAAAADQAAAGMAAADAAAAAFP///wD///8A////AP///wAAAACdAAAAOv///wD///8A////AP///wD///8A////AP///wD///8AAAAAOgAAAJ3///8A////AP///wAAAAAnAAAAcP///wAAAAAoAAAASv///wD///8A////AP///wAAAABKAAAAKP///wAAAABwAAAAJ////wD///8AAAAAgQAAABwAAACIAAAAkAAAAJMAAACtAAAAFQAAABUAAACtAAAAkwAAAJAAAACIAAAAHAAAAIH///8A////AAAAAKQAAACrAAAAaP///wD///8AAAAARQAAANIAAADSAAAARf///wD///8AAAAAaAAAAKsAAACk////AAAAADMAAACcAAAAnQAAABj///8A////AP///wAAAAAYAAAAGP///wD///8A////AAAAABgAAACdAAAAnAAAADMAAAB1AAAAwwAAAP8AAADpAAAAsQAAAE4AAAAb////AP///wAAAAAbAAAATgAAALEAAADpAAAA/wAAAMMAAAB1AAAAtwAAAOkAAAD/AAAA/wAAAP8AAADvAAAA3gAAAN4AAADeAAAA3gAAAO8AAAD/AAAA/wAAAP8AAADpAAAAtwAAAGUAAAA/AAAA3wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAADfAAAAPwAAAGX///8A////AAAAAEgAAADtAAAAvwAAAL0AAADGAAAA7wAAAO8AAADGAAAAvQAAAL8AAADtAAAASP///wD///8A////AP///wD///8AAAAAO////wD///8A////AAAAAIcAAACH////AP///wD///8AAAAAO////wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A//8AAP//AAD4HwAA7/cAAN/7AAD//wAAoYUAAJ55AACf+QAAh+EAAAAAAADAAwAA4AcAAP5/AAD//wAA//8AAA=="/>
+<link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4QQQEwksSS9ZWwAAAk1JREFUWMPtll2ITVEUx39nn/O7Y5qR8f05wtCUUr6ZIS++8pEnkZInPImneaCQ5METNdOkeFBKUhMPRIkHKfEuUZSUlGlKPN2TrgfncpvmnntnmlEyq1Z7t89/rf9a6+y99oZxGZf/XeIq61EdtgKXgdXA0xrYAvBjOIF1AI9zvjcC74BSpndrJPkBWDScTF8Aa4E3wDlgHbASaANmVqlcCnwHvgDvgVfAJ+AikAAvgfVZwLnSVZHZaOuKoQi3ZOMi4NkYkpe1p4J7A8BpYAD49hfIy/oqG0+hLomiKP2L5L+1ubn5115S+3OAn4EnwBlgMzCjyt6ZAnQCJ4A7wOs88iRJHvw50HoujuPBoCKwHWiosy8MdfZnAdcHk8dxXFJ3VQbQlCTJvRBCGdRbD4M6uc5glpY3eAihpN5S5w12diSEcCCEcKUO4ljdr15T76ur1FDDLIQQ3qv71EdDOe3Kxj3leRXyk+pxdWnFWod6Wt2bY3de3aSuUHcPBVimHs7mK9WrmeOF6lR1o9qnzskh2ar2qm1qizpfXaPeVGdlmGN5pb09qMxz1Xb1kLqgzn1RyH7JUXW52lr5e/Kqi9qpto7V1atuUzfnARrV7jEib1T76gG2qxdGmXyiekkt1GswPTtek0aBfJp6YySGBfWg2tPQ0FAYgf1stUfdmdcjarbYJEniKIq6gY/Aw+zWHAC+p2labGpqiorFYgGYCEzN7oQdQClN07O1/EfDyGgC0ALMBdYAi4FyK+4H3gLPsxfR1zRNi+NP7nH5J+QntnXe5B5mpfQAAAAASUVORK5CYII=">
 
 <!-- Google fonts -->
 <link href='https://fonts.googleapis.com/css?family=Lato:400,600,900' rel='stylesheet' type='text/css'/>
 <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600' rel='stylesheet' type='text/css'/>
 
 <!-- CSS -->
-<title>Module nimgraphviz</title>
+<title>nimgraphviz</title>
 <style type="text/css" >
 /*
 Stylesheet for use with Docutils/rst2html.
@@ -27,232 +28,130 @@ customize this style sheet.
 Modified from Chad Skeeters' rst2html-style
 https://bitbucket.org/cskeeters/rst2html-style/
 
-Modified by Boyd Greenfield
+Modified by Boyd Greenfield and narimiran
 */
-/* SCSS variables */
-/* Text weights */
-/* Body colors */
-/* Text colors */
-/* Link colors */
-/* Syntax highlighting colors */
-/* Pct changes */
-/* Mixins */
-/* Body/layout */
+
 html {
   font-size: 100%;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%; }
 
-/* Where we want fancier font if available */
-h1, h2, h3, h4, h5, h6, p.module-desc, table.docinfo + blockquote p, table.docinfo blockquote p, h1 + blockquote p {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif !important; }
-
-h1.title {
-  font-weight: 900; }
-
 body {
   font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
   font-weight: 400;
-  font-size: 16px;
-  line-height: 20px;
-  color: #444;
-  letter-spacing: 0.15px;
-  background-color: rgba(252, 248, 244, 0.45); }
+  font-size: 1.125em;
+  line-height: 1.5;
+  color: #222;
+  background-color: #FCFCFC; }
 
 /* Skeleton grid */
 .container {
   position: relative;
   width: 100%;
-  max-width: 960px;
+  max-width: 1050px;
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0;
   box-sizing: border-box; }
 
 .column,
 .columns {
   width: 100%;
   float: left;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+  margin-left: 1%;
+}
 
-/* For devices larger than 400px */
-@media (min-width: 400px) {
-  .container {
-    width: 100%;
-    padding: 0; } }
-/* For devices larger than 650px */
-@media (min-width: 650px) {
-  .container {
-    width: 100%; }
+.column:first-child,
+.columns:first-child {
+  margin-left: 0; }
 
-  .column,
-  .columns {
-    margin-left: 4%; }
+.three.columns {
+  width: 19%; }
 
-  .column:first-child,
-  .columns:first-child {
-    margin-left: 0; }
+.nine.columns {
+  width: 80.0%; }
 
-  .one.column,
-  .one.columns {
-    width: 4.66666666667%; }
+.twelve.columns {
+  width: 100%;
+  margin-left: 0; }
 
-  .two.columns {
-    width: 13.3333333333%; }
-
+@media screen and (max-width: 860px) {
   .three.columns {
-    width: 22%; }
-
-  .four.columns {
-    width: 30.6666666667%; }
-
-  .five.columns {
-    width: 39.3333333333%; }
-
-  .six.columns {
-    width: 48%; }
-
-  .seven.columns {
-    width: 56.6666666667%; }
-
-  .eight.columns {
-    width: 65.3333333333%; }
-
+    display: none;
+  }
   .nine.columns {
-    width: 74.0%; }
-
-  .ten.columns {
-    width: 82.6666666667%; }
-
-  .eleven.columns {
-    width: 91.3333333333%; }
-
-  .twelve.columns {
-    width: 100%;
-    margin-left: 0; }
-
-  .one-third.column {
-    width: 30.6666666667%; }
-
-  .two-thirds.column {
-    width: 65.3333333333%; } }
-/* Customer Overrides */
-.footer {
-  text-align: center;
-  color: #969696;
-  padding-top: 10%; }
-
-p.module-desc {
-  font-size: 1.1em;
-  color: #666666; }
-
-a.link-seesrc {
-  color: #aec7d2;
-  font-style: italic; }
-
-a.link-seesrc:hover {
-  color: #6c9aae; }
-
-#toc-list {
-  word-wrap: break-word; }
-
-ul.simple-toc {
-  list-style: none; }
-
-ul.simple-toc a.reference-toplevel {
-  font-weight: bold;
-  color: #0077b3; }
-
-ul.simple-toc-section {
-  list-style-type: circle;
-  color: #6c9aae; }
-
-ul.simple-toc-section a.reference {
-  color: #0077b3; }
+    width: 98.0%;
+  }
+  body {
+    font-size: 1em;
+    line-height: 1.35;
+  }
+}
 
 cite {
   font-style: italic !important; }
 
-dt > pre {
-  border-color: rgba(0, 0, 0, 0.1);
-  background-color: rgba(255, 255, 255, 0.3);
-  margin: 15px 0px 5px; }
-
-dd > pre {
-  border-color: rgba(0, 0, 0, 0.1);
-  background-color: whitesmoke;
-  margin-top: 8px; }
-
-.item > dd {
-  margin-left: 10px;
-  margin-bottom: 30px; }
-
-/* Nim line-numbered tables */
-.line-nums-table {
-  width: 100%;
-  table-layout: fixed; }
 
 /* Nim search input */
-div#searchInput {
-  margin-bottom: 8px;
+div#searchInputDiv {
+  margin-bottom: 1em;
 }
-div#searchInput input#searchInput {
-  width: 10em;
-}
-div.search-groupby {
-  margin-bottom: 8px;
+input#searchInput {
+  width: 80%;
 }
 
-table.line-nums-table {
-  border-radius: 4px;
-  border: 1px solid #cccccc;
-  background-color: whitesmoke;
-  border-collapse: separate;
-  margin-top: 15px;
-  margin-bottom: 25px; }
-
-.line-nums-table tbody {
-  border: none; }
-
-.line-nums-table td pre {
-  border: none;
-  background-color: transparent; }
-
-.line-nums-table td.blob-line-nums {
-  width: 28px; }
-
-.line-nums-table td.blob-line-nums pre {
-  color: #b0b0b0;
-  -webkit-filter: opacity(75%);
-  text-align: right;
-  border-color: transparent;
-  background-color: transparent;
-  padding-left: 0px;
-  margin-left: 0px;
-  padding-right: 0px;
-  margin-right: 0px; }
+/*
+ * Some custom formatting for input forms.
+ * This also fixes input form colors on Firefox with a dark system theme on Linux.
+ */
+input {
+  -moz-appearance: none;
+  color: #333;
+  background-color: #f8f8f8;
+  border: 1px solid #aaa;
+  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  padding: 6px;
+}
+input:focus {
+  border: 1px solid #1fa0eb;
+  box-shadow: 0 0 2px #1fa0eb;
+}
 
 /* Docgen styles */
 /* Links */
 a {
-  color: #0077b3;
-  text-decoration: none; }
+  color: #07b;
+  text-decoration: none;
+}
+
+a span.Identifier {
+  text-decoration: underline;
+  text-decoration-color: #aab;
+}
+
+a.reference-toplevel {
+  font-weight: bold;
+}
+
+a.toc-backref {
+  text-decoration: none;
+  color: #222; }
+
+a.link-seesrc {
+  color: #607c9f;
+  font-size: 0.9em;
+  font-style: italic; }
 
 a:hover,
 a:focus {
-  color: #00334d;
+  color: #607c9f;
   text-decoration: underline; }
 
-a:visited {
-  color: #00334d; }
+a:hover span.Identifier {
+  color: #607c9f;
+}
 
-a:focus {
-  outline: thin dotted #2d2d2d;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px; }
-
-a:hover,
-a:active {
-  outline: 0; }
 
 sub,
 sup {
@@ -329,379 +228,258 @@ img {
 
   h2,
   h3 {
-    page-break-after: avoid; } }
-.img-rounded {
-  -webkit-border-radius: 6px;
-  -moz-border-radius: 6px;
-  border-radius: 6px; }
+    page-break-after: avoid; }
+}
 
-.img-polaroid {
-  padding: 4px;
-  background-color: rgba(252, 248, 244, 0.75);
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1); }
 
 p {
-  margin: 0 0 8px; }
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
 
 small {
   font-size: 85%; }
 
 strong {
-  font-weight: 600; }
+  font-weight: 600;
+  font-size: 0.95em;
+  color: #3c3c3c;
+}
 
 em {
   font-style: italic; }
 
-cite {
-  font-style: normal; }
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
-  font-weight: 600;
-  line-height: 20px;
-  color: inherit;
-  text-rendering: optimizelegibility; }
-
 h1 {
-  font-size: 2em;
+  font-size: 1.8em;
   font-weight: 400;
-  padding-bottom: .15em;
-  border-bottom: 1px solid #aaaaaa;
-  margin-top: 1.0em;
+  padding-bottom: .25em;
+  border-bottom: 1px solid #aaa;
+  margin-top: 2.5em;
+  margin-bottom: 1em;
   line-height: 1.2em; }
 
 h1.title {
   padding-bottom: 1em;
   border-bottom: 0px;
-  font-size: 2.75em; }
+  font-size: 2.5em;
+  text-align: center;
+  font-weight: 900;
+  margin-top: 0.75em;
+  margin-bottom: 0em;
+}
 
 h2 {
-  font-size: 1.5em;
-  margin-top: 1.5em; }
+  font-size: 1.3em;
+  margin-top: 2em; }
+
+h2.subtitle {
+  text-align: center; }
 
 h3 {
-  font-size: 1.3em;
+  font-size: 1.125em;
   font-style: italic;
-  margin-top: 0.75em; }
+  margin-top: 1.5em; }
 
 h4 {
-  font-size: 1.3em;
-  margin-top: 0.5em; }
+  font-size: 1.125em;
+  margin-top: 1em; }
 
 h5 {
-  font-size: 1.2em;
-  margin-top: 0.25em; }
+  font-size: 1.125em;
+  margin-top: 0.75em; }
 
 h6 {
   font-size: 1.1em; }
 
+
 ul,
 ol {
   padding: 0;
-  margin: 0 0 0px 15px; }
+  margin-top: 0.5em;
+  margin-left: 0.75em; }
 
 ul ul,
 ul ol,
 ol ol,
 ol ul {
-  margin-bottom: 0; }
+  margin-bottom: 0;
+  margin-left: 1.25em; }
 
 li {
-  line-height: 20px; }
-
-dl {
-  margin-bottom: 20px; }
-
-dt,
-dd {
-  line-height: 20px; }
-
-dt {
-  font-weight: bold; }
-
-dd {
-  margin-left: 10px;
-  margin-bottom: 26px; }
-
-hr {
-  margin: 20px 0;
-  border: 0;
-  border-top: 1px solid #eeeeee;
-  border-bottom: 1px solid #ffffff; }
-
-abbr[title],
-abbr[data-original-title] {
-  cursor: help;
-  border-bottom: 1px dotted #999999; }
-
-abbr.initialism {
-  font-size: 90%;
-  text-transform: uppercase; }
-
-blockquote {
-  padding: 0 0 0 15px;
-  margin: 0 0 20px;
-  border-left: 5px solid #EFEBE0; }
-
-table.docinfo + blockquote, table.docinfo blockquote, h1 + blockquote {
-  border-left: 5px solid #c9c9c9;
+    list-style-type: circle;
 }
 
-table.docinfo + blockquote p, table.docinfo blockquote p, h1 + blockquote p {
-  margin-bottom: 0;
-  font-size: 15px;
-  font-weight: 200;
-  line-height: 1.5;
-  font-style: italic; }
+ul.simple-boot li {
+    list-style-type: none;
+    margin-left: 0em;
+    margin-bottom: 0.5em;
+}
 
-q:before,
-q:after,
-blockquote:before,
-blockquote:after {
-  content: ""; }
+ol.simple > li, ul.simple > li {
+  margin-bottom: 0.25em;
+  margin-left: 0.4em }
 
-address {
-  display: block;
-  margin-bottom: 20px;
-  font-style: normal;
-  line-height: 20px; }
+ul.simple.simple-toc > li {
+    margin-top: 1em;
+}
 
-code,
-pre {
-  font-family: "Source Code Pro", Monaco, Menlo, Consolas, "Courier New", monospace;
-  padding: 0 3px 2px;
-  font-weight: 500;
-  font-size: 12px;
-  color: #444444;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px; }
+ul.simple-toc {
+  list-style: none;
+  font-size: 0.9em;
+  margin-left: -0.3em;
+  margin-top: 1em; }
+
+ul.simple-toc > li {
+    list-style-type: none;
+}
+
+ul.simple-toc-section {
+  list-style-type: circle;
+  margin-left: 1em;
+  color: #6c9aae; }
+
+
+ol.arabic {
+  list-style: decimal; }
+
+ol.loweralpha {
+  list-style: lower-alpha; }
+
+ol.upperalpha {
+  list-style: upper-alpha; }
+
+ol.lowerroman {
+  list-style: lower-roman; }
+
+ol.upperroman {
+  list-style: upper-roman; }
+
+ul.auto-toc {
+  list-style-type: none; }
+
+
+dl {
+  margin-bottom: 1.5em; }
+
+dt {
+  margin-bottom: -0.5em;
+  margin-left: 0.0em; }
+
+dd {
+  margin-left: 2.0em;
+  margin-bottom: 3.0em;
+  margin-top: 0.5em; }
+
+
+hr {
+  margin: 2em 0;
+  border: 0;
+  border-top: 1px solid #aaa; }
+
+blockquote {
+  font-size: 0.9em;
+  font-style: italic;
+  padding-left: 0.5em;
+  margin-left: 0;
+  border-left: 5px solid #bbc;
+}
 
 .pre {
   font-family: "Source Code Pro", Monaco, Menlo, Consolas, "Courier New", monospace;
-  font-weight: 600;
-  /*color: #504da6;*/
+  font-weight: 500;
+  font-size: 0.85em;
+  background-color: #f0f3ff;
+  padding-left: 3px;
+  padding-right: 3px;
+  border-radius: 4px;
 }
 
-code {
-  padding: 2px 4px;
-  color: #444444;
-  white-space: nowrap;
-  background-color: white;
-  border: 1px solid #777777; }
-
 pre {
+  font-family: "Source Code Pro", Monaco, Menlo, Consolas, "Courier New", monospace;
+  color: #222;
+  font-weight: 500;
   display: inline-block;
   box-sizing: border-box;
-  min-width: calc(100% - 19.5px);
-  padding: 9.5px;
-  margin: 0.25em 10px 10px 10px;
-  font-size: 15px;
-  line-height: 20px;
+  min-width: 100%;
+  padding: 0.5em;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  font-size: 0.85em;
   white-space: pre !important;
   overflow-y: hidden;
   overflow-x: visible;
-  background-color: rgba(0, 0, 0, 0.01);
-  border: 1px solid #cccccc;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px; }
-
-pre.prettyprint {
-  margin-bottom: 20px; }
-
-pre code {
-  padding: 0;
-  color: inherit;
-  white-space: pre;
-  overflow-x: visible;
-  background-color: transparent;
-  border: 0; }
+  background-color: ghostwhite;
+  border: 1px solid #dde;
+  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px; }
 
 .pre-scrollable {
   max-height: 340px;
   overflow-y: scroll; }
 
+
+/* Nim line-numbered tables */
+.line-nums-table {
+  width: 100%;
+  table-layout: fixed; }
+
+table.line-nums-table {
+  border-radius: 4px;
+  border: 1px solid #cccccc;
+  background-color: ghostwhite;
+  border-collapse: separate;
+  margin-top: 15px;
+  margin-bottom: 25px; }
+
+.line-nums-table tbody {
+  border: none; }
+
+.line-nums-table td pre {
+  border: none;
+  background-color: transparent; }
+
+.line-nums-table td.blob-line-nums {
+  width: 28px; }
+
+.line-nums-table td.blob-line-nums pre {
+  color: #b0b0b0;
+  -webkit-filter: opacity(75%);
+  text-align: right;
+  border-color: transparent;
+  background-color: transparent;
+  padding-left: 0px;
+  margin-left: 0px;
+  padding-right: 0px;
+  margin-right: 0px; }
+
+
 table {
   max-width: 100%;
   background-color: transparent;
+  margin-top: 0.5em;
+  margin-bottom: 1.5em;
   border-collapse: collapse;
-  border-spacing: 0; }
-
-table th, table td {
-  padding: 0px 8px 0px;
+  border-color: #ccc;
+  border-spacing: 0;
+  font-size: 0.9em;
 }
 
-.table {
-  width: 100%;
-  margin-bottom: 20px; }
+table th, table td {
+  padding: 0px 0.5em 0px;
+}
 
-.table th,
-.table td {
-  padding: 8px;
-  line-height: 20px;
-  text-align: left;
-  vertical-align: top;
-  border-top: 1px solid #444444; }
-
-.table th {
+table th {
+  background-color: #e8e8e8;
   font-weight: bold; }
 
-.table thead th {
-  vertical-align: bottom; }
+table th.docinfo-name {
+    background-color: transparent;
+}
 
-.table caption + thead tr:first-child th,
-.table caption + thead tr:first-child td,
-.table colgroup + thead tr:first-child th,
-.table colgroup + thead tr:first-child td,
-.table thead:first-child tr:first-child th,
-.table thead:first-child tr:first-child td {
-  border-top: 0; }
+table tr:hover {
+  background-color: ghostwhite; }
 
-.table tbody + tbody {
-  border-top: 2px solid #444444; }
-
-.table .table {
-  background-color: rgba(252, 248, 244, 0.75); }
-
-.table-condensed th,
-.table-condensed td {
-  padding: 4px 5px; }
-
-.table-bordered {
-  border: 1px solid #444444;
-  border-collapse: separate;
-  *border-collapse: collapse;
-  border-left: 0;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px; }
-
-.table-bordered th,
-.table-bordered td {
-  border-left: 1px solid #444444; }
-
-.table-bordered caption + thead tr:first-child th,
-.table-bordered caption + tbody tr:first-child th,
-.table-bordered caption + tbody tr:first-child td,
-.table-bordered colgroup + thead tr:first-child th,
-.table-bordered colgroup + tbody tr:first-child th,
-.table-bordered colgroup + tbody tr:first-child td,
-.table-bordered thead:first-child tr:first-child th,
-.table-bordered tbody:first-child tr:first-child th,
-.table-bordered tbody:first-child tr:first-child td {
-  border-top: 0; }
-
-.table-bordered thead:first-child tr:first-child > th:first-child,
-.table-bordered tbody:first-child tr:first-child > td:first-child,
-.table-bordered tbody:first-child tr:first-child > th:first-child {
-  -webkit-border-top-left-radius: 4px;
-  border-top-left-radius: 4px;
-  -moz-border-radius-topleft: 4px; }
-
-.table-bordered thead:first-child tr:first-child > th:last-child,
-.table-bordered tbody:first-child tr:first-child > td:last-child,
-.table-bordered tbody:first-child tr:first-child > th:last-child {
-  -webkit-border-top-right-radius: 4px;
-  border-top-right-radius: 4px;
-  -moz-border-radius-topright: 4px; }
-
-.table-bordered thead:last-child tr:last-child > th:first-child,
-.table-bordered tbody:last-child tr:last-child > td:first-child,
-.table-bordered tbody:last-child tr:last-child > th:first-child,
-.table-bordered tfoot:last-child tr:last-child > td:first-child,
-.table-bordered tfoot:last-child tr:last-child > th:first-child {
-  -webkit-border-bottom-left-radius: 4px;
-  border-bottom-left-radius: 4px;
-  -moz-border-radius-bottomleft: 4px; }
-
-.table-bordered thead:last-child tr:last-child > th:last-child,
-.table-bordered tbody:last-child tr:last-child > td:last-child,
-.table-bordered tbody:last-child tr:last-child > th:last-child,
-.table-bordered tfoot:last-child tr:last-child > td:last-child,
-.table-bordered tfoot:last-child tr:last-child > th:last-child {
-  -webkit-border-bottom-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  -moz-border-radius-bottomright: 4px; }
-
-.table-bordered tfoot + tbody:last-child tr:last-child td:first-child {
-  -webkit-border-bottom-left-radius: 0;
-  border-bottom-left-radius: 0;
-  -moz-border-radius-bottomleft: 0; }
-
-.table-bordered tfoot + tbody:last-child tr:last-child td:last-child {
-  -webkit-border-bottom-right-radius: 0;
-  border-bottom-right-radius: 0;
-  -moz-border-radius-bottomright: 0; }
-
-.table-bordered caption + thead tr:first-child th:first-child,
-.table-bordered caption + tbody tr:first-child td:first-child,
-.table-bordered colgroup + thead tr:first-child th:first-child,
-.table-bordered colgroup + tbody tr:first-child td:first-child {
-  -webkit-border-top-left-radius: 4px;
-  border-top-left-radius: 4px;
-  -moz-border-radius-topleft: 4px; }
-
-.table-bordered caption + thead tr:first-child th:last-child,
-.table-bordered caption + tbody tr:first-child td:last-child,
-.table-bordered colgroup + thead tr:first-child th:last-child,
-.table-bordered colgroup + tbody tr:first-child td:last-child {
-  -webkit-border-top-right-radius: 4px;
-  border-top-right-radius: 4px;
-  -moz-border-radius-topright: 4px; }
-
-table.docutils th {
-  background-color: #e8e8e8; }
-
-table.docutils tr:hover {
-  background-color: whitesmoke; }
-
-.table-striped tbody > tr:nth-child(odd) > td,
-.table-striped tbody > tr:nth-child(odd) > th {
-  background-color: rgba(252, 248, 244, 0.75); }
-
-.table-hover tbody tr:hover > td,
-.table-hover tbody tr:hover > th {
-  background-color: rgba(241, 222, 204, 0.75); }
-
-table td[class*="span"],
-table th[class*="span"],
-.row-fluid table td[class*="span"],
-.row-fluid table th[class*="span"] {
-  display: table-cell;
-  float: none;
-  margin-left: 0; }
-
-.hero-unit {
-  padding: 60px;
-  margin-bottom: 30px;
-  font-size: 18px;
-  font-weight: 200;
-  line-height: 30px;
-  color: inherit;
-  background-color: rgba(230, 197, 164, 0.75);
-  -webkit-border-radius: 6px;
-  -moz-border-radius: 6px;
-  border-radius: 6px; }
-
-.hero-unit h1 {
-  margin-bottom: 0;
-  font-size: 60px;
-  line-height: 1;
-  letter-spacing: -1px;
-  color: inherit; }
-
-.hero-unit li {
-  line-height: 30px; }
 
 /* rst2html default used to remove borders from tables and images */
 .borderless, table.borderless td, table.borderless th {
@@ -722,10 +500,6 @@ table.borderless td, table.borderless th {
 .hidden {
   display: none; }
 
-a.toc-backref {
-  text-decoration: none;
-  color: #444444; }
-
 blockquote.epigraph {
   margin: 2em 5em; }
 
@@ -735,85 +509,6 @@ dl.docutils dd {
 object[type="image/svg+xml"], object[type="application/x-shockwave-flash"] {
   overflow: hidden; }
 
-/* Uncomment (and remove this text!) to get bold-faced definition list terms
-dl.docutils dt {
-  font-weight: bold }
-*/
-div.abstract {
-  margin: 2em 5em; }
-
-div.abstract p.topic-title {
-  font-weight: bold;
-  text-align: center; }
-
-div.admonition, div.attention, div.caution, div.danger, div.error,
-div.hint, div.important, div.note, div.tip, div.warning {
-  margin: 2em;
-  border: medium outset;
-  padding: 1em; }
-
-div.note, div.warning {
-  margin: 1.5em 0px;
-  border: none; }
-
-div.note p.admonition-title,
-div.warning p.admonition-title {
-  display: none; }
-
-/* Clearfix
- * http://css-tricks.com/snippets/css/clear-fix/
- */
-div.note:after,
-div.warning:after {
-  content: "";
-  display: table;
-  clear: both; }
-
-div.note p:before,
-div.warning p:before {
-  display: block;
-  float: left;
-  font-size: 4em;
-  line-height: 1em;
-  margin-right: 20px;
-  margin-left: 0em;
-  margin-top: -10px;
-  content: '\0270D';
-  /*handwriting*/ }
-
-div.warning p:before {
-  content: '\026A0';
-  /*warning*/ }
-
-div.admonition p.admonition-title, div.hint p.admonition-title,
-div.important p.admonition-title, div.note p.admonition-title,
-div.tip p.admonition-title {
-  font-weight: bold;
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif; }
-
-div.attention p.admonition-title, div.caution p.admonition-title,
-div.danger p.admonition-title, div.error p.admonition-title,
-div.warning p.admonition-title, .code .error {
-  color: #b30000;
-  font-weight: bold;
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif; }
-
-/* Uncomment (and remove this text!) to get reduced vertical space in
-   compound paragraphs.
-div.compound .compound-first, div.compound .compound-middle {
-  margin-bottom: 0.5em }
-
-div.compound .compound-last, div.compound .compound-middle {
-  margin-top: 0.5em }
-*/
-div.dedication {
-  margin: 2em 5em;
-  text-align: center;
-  font-style: italic; }
-
-div.dedication p.topic-title {
-  font-weight: bold;
-  font-style: normal; }
 
 div.figure {
   margin-left: 2em;
@@ -821,7 +516,13 @@ div.figure {
 
 div.footer, div.header {
   clear: both;
+  text-align: center;
+  color: #666;
   font-size: smaller; }
+
+div.footer {
+    padding-top: 5em;
+}
 
 div.line-block {
   display: block;
@@ -833,45 +534,24 @@ div.line-block div.line-block {
   margin-bottom: 0;
   margin-left: 1.5em; }
 
-div.sidebar {
-  margin: 0 0 0.5em 1em;
-  border: medium outset;
-  padding: 1em;
-  background-color: rgba(252, 248, 244, 0.75);
-  width: 40%;
-  float: right;
-  clear: right; }
-
-div.sidebar p.rubric {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
-  font-size: medium; }
-
-div.system-messages {
-  margin: 5em; }
-
-div.system-messages h1 {
-  color: #b30000; }
-
-div.system-message {
-  border: medium outset;
-  padding: 1em; }
-
-div.system-message p.system-message-title {
-  color: #b30000;
-  font-weight: bold; }
-
 div.topic {
   margin: 2em; }
 
-h1.section-subtitle, h2.section-subtitle, h3.section-subtitle,
-h4.section-subtitle, h5.section-subtitle, h6.section-subtitle {
-  margin-top: 0.4em; }
+div.search_results {
+  background-color: antiquewhite;
+  margin: 3em;
+  padding: 1em;
+  border: 1px solid #4d4d4d;
+}
 
-h1.title {
-  text-align: center; }
+div#global-links ul {
+  margin-left: 0;
+  list-style-type: none;
+}
 
-h2.subtitle {
-  text-align: center; }
+div#global-links > simple-boot {
+    margin-left: 3em;
+}
 
 hr.docutils {
   width: 75%; }
@@ -905,30 +585,6 @@ img.align-center, .figure.align-center, object.align-center {
 div.align-right {
   text-align: inherit; }
 
-/* div.align-center * { */
-/*   text-align: left } */
-
-ul.simple > li {
-  margin-bottom: 0.5em }
-
-ol.simple, ul.simple {
-  margin-bottom: 1em; }
-
-ol.arabic {
-  list-style: decimal; }
-
-ol.loweralpha {
-  list-style: lower-alpha; }
-
-ol.upperalpha {
-  list-style: upper-alpha; }
-
-ol.lowerroman {
-  list-style: lower-roman; }
-
-ol.upperroman {
-  list-style: upper-roman; }
-
 p.attribution {
   text-align: right;
   margin-left: 50%; }
@@ -948,15 +604,6 @@ p.rubric {
   font-size: larger;
   color: maroon;
   text-align: center; }
-
-p.sidebar-title {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
-  font-weight: bold;
-  font-size: larger; }
-
-p.sidebar-subtitle {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
-  font-weight: bold; }
 
 p.topic-title {
   font-weight: bold; }
@@ -997,21 +644,13 @@ pre.code .inserted, code .inserted {
   background-color: #A3D289; }
 
 span.classifier {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
   font-style: oblique; }
 
 span.classifier-delimiter {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
   font-weight: bold; }
-
-span.interpreted {
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif; }
 
 span.option {
   white-space: nowrap; }
-
-span.pre {
-  white-space: pre; }
 
 span.problematic {
   color: #b30000; }
@@ -1019,44 +658,6 @@ span.problematic {
 span.section-subtitle {
   /* font-size relative to parent (h1..h6 element) */
   font-size: 80%; }
-
-table.citation {
-  border-left: solid 1px #666666;
-  margin-left: 1px; }
-
-table.docinfo {
-  margin: 0em;
-  margin-top: 2em;
-  margin-bottom: 2em;
-  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif !important;
-  color: #444444; }
-
-table.docutils {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em; }
-
-table.footnote {
-  border-left: solid 1px #2d2d2d;
-  margin-left: 1px; }
-
-table.docutils td, table.docutils th,
-table.docinfo td, table.docinfo th {
-  padding-left: 0.5em;
-  padding-right: 0.5em;
-  vertical-align: top; }
-
-table.docutils th.field-name, table.docinfo th.docinfo-name {
-  font-weight: 700;
-  text-align: left;
-  white-space: nowrap;
-  padding-left: 0; }
-
-h1 tt.docutils, h2 tt.docutils, h3 tt.docutils,
-h4 tt.docutils, h5 tt.docutils, h6 tt.docutils {
-  font-size: 100%; }
-
-ul.auto-toc {
-  list-style-type: none; }
 
 span.DecNumber {
   color: #252dbe; }
@@ -1074,7 +675,7 @@ span.FloatNumber {
   color: #252dbe; }
 
 span.Identifier {
-  color: #3b3b3b; }
+  color: #222; }
 
 span.Keyword {
   font-weight: 600;
@@ -1139,72 +740,63 @@ dt pre > span.Identifier, dt pre > span.Operator {
   color: #155da4;
   font-weight: 700; }
 
-dt pre > span.Identifier ~ span.Identifier, dt pre > span.Operator ~ span.Identifier {
-  color: inherit;
-  font-weight: inherit; }
-
-dt pre > span.Operator ~ span.Identifier, dt pre > span.Operator ~ span.Operator {
+dt pre > span.Keyword ~ span.Identifier, dt pre > span.Identifier ~ span.Identifier,
+dt pre > span.Operator ~ span.Identifier, dt pre > span.Other ~ span.Identifier {
   color: inherit;
   font-weight: inherit; }
 
 /* Nim sprite for the footer (taken from main page favicon) */
 .nim-sprite {
   display: inline-block;
-  height: 12px;
-  width: 12px;
+  height: 16px;
+  width: 16px;
   background-position: 0 0;
-  background-size: 12px 12px;
+  background-size: 16px 16px;
   -webkit-filter: opacity(50%);
   background-repeat: no-repeat;
   background-image: url("data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AAAAAAUAAAAF////AP///wD///8A////AP///wD///8A////AP///wD///8A////AAAAAAIAAABbAAAAlQAAAKIAAACbAAAAmwAAAKIAAACVAAAAWwAAAAL///8A////AP///wD///8A////AAAAABQAAADAAAAAYwAAAA3///8A////AP///wD///8AAAAADQAAAGMAAADAAAAAFP///wD///8A////AP///wAAAACdAAAAOv///wD///8A////AP///wD///8A////AP///wD///8AAAAAOgAAAJ3///8A////AP///wAAAAAnAAAAcP///wAAAAAoAAAASv///wD///8A////AP///wAAAABKAAAAKP///wAAAABwAAAAJ////wD///8AAAAAgQAAABwAAACIAAAAkAAAAJMAAACtAAAAFQAAABUAAACtAAAAkwAAAJAAAACIAAAAHAAAAIH///8A////AAAAAKQAAACrAAAAaP///wD///8AAAAARQAAANIAAADSAAAARf///wD///8AAAAAaAAAAKsAAACk////AAAAADMAAACcAAAAnQAAABj///8A////AP///wAAAAAYAAAAGP///wD///8A////AAAAABgAAACdAAAAnAAAADMAAAB1AAAAwwAAAP8AAADpAAAAsQAAAE4AAAAb////AP///wAAAAAbAAAATgAAALEAAADpAAAA/wAAAMMAAAB1AAAAtwAAAOkAAAD/AAAA/wAAAP8AAADvAAAA3gAAAN4AAADeAAAA3gAAAO8AAAD/AAAA/wAAAP8AAADpAAAAtwAAAGUAAAA/AAAA3wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAADfAAAAPwAAAGX///8A////AAAAAEgAAADtAAAAvwAAAL0AAADGAAAA7wAAAO8AAADGAAAAvQAAAL8AAADtAAAASP///wD///8A////AP///wD///8AAAAAO////wD///8A////AAAAAIcAAACH////AP///wD///8AAAAAO////wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A////AP///wD///8A//8AAP//AAD4HwAA7/cAAN/7AAD//wAAoYUAAJ55AACf+QAAh+EAAAAAAADAAwAA4AcAAP5/AAD//wAA//8AAA==");
   margin-bottom: -5px; }
-div.pragma {
+
+span.pragmadots {
+  /* Position: relative frees us up to make the dots
+  look really nice without fucking up the layout and
+  causing bulging in the parent container */
+  position: relative;
+  /* 1px down looks slightly nicer */
+  top: 1px;
+  padding: 2px;
+  background-color: #e8e8e8;
+  border-radius: 4px;
+  margin: 0 2px;
+  cursor: pointer;
+  font-size: 0.8em;
+}
+
+span.pragmadots:hover {
+  background-color: #DBDBDB;
+}
+span.pragmawrap {
   display: none;
 }
-span.pragmabegin {
-  cursor: pointer;
-}
-span.pragmaend {
-  cursor: pointer;
-}
 
-div.search_results {
-  background-color: antiquewhite;
-  margin: 3em;
-  padding: 1em;
-  border: 1px solid #4d4d4d;
-}
-
-div#global-links ul {
-  margin-left: 0;
-  list-style-type: none;
+span.attachedType {
+  display: none;
+  visibility: hidden;
 }
 </style>
 
-<script type="text/javascript" src="../dochack.js"></script>
+<script type="text/javascript" src="dochack.js"></script>
 
 <script type="text/javascript">
-function togglepragma(d) {
-  if (d.style.display != 'inline')
-    d.style.display = 'inline';
-  else
-    d.style.display = 'none';
-}
-
 function main() {
-  var elements = document.getElementsByClassName("pragmabegin");
-  for (var i = 0; i < elements.length; ++i) {
-    var e = elements[i];
-    e.onclick = function(event) {
-      togglepragma(event.target.nextSibling);
-    };
-  }
-  var elements = document.getElementsByClassName("pragmaend");
-  for (var i = 0; i < elements.length; ++i) {
-    var e = elements[i];
-    e.onclick = function(event) {
-      togglepragma(event.target.previousSibling);
-    };
+  var pragmaDots = document.getElementsByClassName("pragmadots");
+  for (var i = 0; i < pragmaDots.length; i++) {
+    pragmaDots[i].onclick = function(event) {
+      // Hide tease
+      event.target.parentNode.style.display = "none";
+      // Show actual
+      event.target.parentNode.nextElementSibling.style.display = "inline";
+    }
   }
 }
 </script>
@@ -1213,14 +805,14 @@ function main() {
 <body onload="main()">
 <div class="document" id="documentId">
   <div class="container">
-    <h1 class="title">Module nimgraphviz</h1>
+    <h1 class="title">nimgraphviz</h1>
     <div class="row">
   <div class="three columns">
   <div id="global-links">
     <ul class="simple">
     </ul>
   </div>
-  <div id="searchInput">
+  <div id="searchInputDiv">
     Search: <input type="text" id="searchInput"
       onkeyup="search()" />
   </div>
@@ -1242,61 +834,109 @@ function main() {
   <a class="reference reference-toplevel" href="#7" id="57">Types</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#Edge"
-    title="Edge = tuple[a, b, key: string]"><wbr />Edge<span class="attachedType" style="visibility:hidden"></span></a></li>
-  <li><a class="reference" href="#Graph"
-    title="Graph = object
-  name*: string
-  isDirected*: bool            ## Whether or not the graph is directed
+    title="Edge = object
+  a*, b*: string"><wbr />Edge<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#DiEdge"
+    title="DiEdge = object
+  a*, b*: string"><wbr />Di<wbr />Edge<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#NodeCollection"
+    title="NodeCollection = ref object of RootObj
+  name*: string                ## The name of the graph
   graphAttr*: Table[string, string] ## A table of key-value pairs
                                  ## describing the layout and
                                  ## appearence of the graph
-  edgesTable: Table[string, HashSet[Edge]]
-  edgeAttrs: Table[Edge, Table[string, string]]
-  nodeAttrs: Table[string, Table[string, string]]"><wbr />Graph<span class="attachedType" style="visibility:hidden"></span></a></li>
+  nodeAttrs*: Table[string, Table[string, string]] ## A table of all the nodes and their attributes"><wbr />Node<wbr />Collection<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#Graph"
+    title="Graph = ref object of NodeCollection
+  subGraphs: seq[Graph]
+  edges*: Table[Edge, Table[string, string]]"><wbr />Graph<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#DiGraph"
+    title="DiGraph = ref object of NodeCollection
+  subGraphs: seq[DiGraph]
+  edges*: Table[DiEdge, Table[string, string]]"><wbr />Di<wbr />Graph<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#GenericGraph"
+    title="GenericGraph = Graph or DiGraph"><wbr />Generic<wbr />Graph<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
 <li>
   <a class="reference reference-toplevel" href="#12" id="62">Procs</a>
   <ul class="simple simple-toc-section">
-      <li><a class="reference" href="#setGraphVizPath,string"
-    title="setGraphVizPath(path: string)"><wbr />set<wbr />Graph<wbr />Viz<wbr />Path<span class="attachedType" style="visibility:hidden"></span></a></li>
-  <li><a class="reference" href="#initGraph,string"
-    title="initGraph(name: string = nil; directed = false): Graph"><wbr />init<wbr />Graph<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#addEdge,Graph,string,string,string"
-    title="addEdge(self: var Graph; a, b: string; key: string = nil)"><wbr />add<wbr />Edge<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#addEdge,Graph,string,string,string,openArray[]"
-    title="addEdge(self: var Graph; a, b: string; key: string; attrs: openArray[(string, string)])"><wbr />add<wbr />Edge<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#edges,Graph"
-    title="edges(self: Graph): seq[Edge]"><wbr />edges<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#edges,Graph,string"
-    title="edges(self: Graph; nbunch: string): seq[Edge]"><wbr />edges<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#addNode,Graph,string,openArray[]"
-    title="addNode(self: var Graph; key: string; attrs: openArray[(string, string)])"><wbr />add<wbr />Node<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#nodes,Graph"
-    title="nodes(self: Graph): seq[string]"><wbr />nodes<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#degree,Graph,string"
-    title="degree(self: Graph; node: string): int"><wbr />degree<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#inDegree,Graph,string"
-    title="inDegree(self: Graph; node: string): int"><wbr />in<wbr />Degree<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#outDegree,Graph,string"
-    title="outDegree(self: Graph; node: string): int"><wbr />out<wbr />Degree<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#exportDot,Graph"
-    title="exportDot(self: Graph): string"><wbr />export<wbr />Dot<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#exportImage,Graph,string,string,string"
-    title="exportImage(self: Graph; fileName: string = nil; layout = &quot;dot&quot;; format = &quot;png&quot;)"><wbr />export<wbr />Image<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
+      <li><a class="reference" href="#exportImage%2CGenericGraph%2Cstring%2Cstring%2Cstring%2Cstring"
+    title="exportImage(self: GenericGraph; fileName: string; layout = &quot;dot&quot;; format = &quot;&quot;;
+            exec = &quot;dot&quot;)"><wbr />export<wbr />Image<span class="attachedType">GenericGraph</span></a></li>
+
+  </ul>
+</li>
+<li>
+  <a class="reference reference-toplevel" href="#13" id="63">Funcs</a>
+  <ul class="simple simple-toc-section">
+      <li><a class="reference" href="#%3D%3D%2CEdge%2CEdge"
+    title="`==`(edge1, edge2: Edge): bool"><wbr />`==`<span class="attachedType">Edge</span></a></li>
+  <li><a class="reference" href="#%3D%3D%2CDiEdge%2CDiEdge"
+    title="`==`(edge1, edge2: DiEdge): bool"><wbr />`==`<span class="attachedType">DiEdge</span></a></li>
+  <li><a class="reference" href="#hash%2CEdge"
+    title="hash(edge: Edge): Hash"><wbr />hash<span class="attachedType">Edge</span></a></li>
+  <li><a class="reference" href="#hash%2CDiEdge"
+    title="hash(edge: DiEdge): Hash"><wbr />hash<span class="attachedType">DiEdge</span></a></li>
+  <li><a class="reference" href="#--%2Cstring%2Cstring"
+    title="`--`(a, b: string): Edge"><wbr />`--`<span class="attachedType">Edge</span></a></li>
+  <li><a class="reference" href="#-%3E%2Cstring%2Cstring"
+    title="`-&gt;`(a, b: string): DiEdge"><wbr />`-&gt;`<span class="attachedType">DiEdge</span></a></li>
+  <li><a class="reference" href="#newGraph"
+    title="newGraph(): Graph"><wbr />new<wbr />Graph<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#newDiGraph"
+    title="newDiGraph(): DiGraph"><wbr />new<wbr />Di<wbr />Graph<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#newSubGraph%2CGraph"
+    title="newSubGraph(parent: Graph): Graph"><wbr />new<wbr />Sub<wbr />Graph<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#newSubGraph%2CDiGraph"
+    title="newSubGraph(parent: DiGraph): DiGraph"><wbr />new<wbr />Sub<wbr />Graph<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#addEdge%2CGraph%2CEdge%2Cvarargs%5B%5D"
+    title="addEdge(self: Graph; edge: Edge; attr: varargs[(string, string)])"><wbr />add<wbr />Edge<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#addEdge%2CDiGraph%2CDiEdge%2Cvarargs%5B%5D"
+    title="addEdge(self: DiGraph; edge: DiEdge; attr: varargs[(string, string)])"><wbr />add<wbr />Edge<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#addNode%2CGenericGraph%2Cstring%2Cvarargs%5B%5D"
+    title="addNode(self: GenericGraph; node: string; attr: varargs[(string, string)])"><wbr />add<wbr />Node<span class="attachedType">GenericGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CGenericGraph%2Cstring"
+    title="`[]`(self: GenericGraph; gAttr: string): string"><wbr />`[]`<span class="attachedType">GenericGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%3D%2CGenericGraph%2Cstring%2Cstring"
+    title="`[]=`(self: GenericGraph; gAttr: string; value: string)"><wbr />`[]=`<span class="attachedType">GenericGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CGenericGraph%2Cstring_2"
+    title="`[]`(self: GenericGraph; node: string): Table[string, string]"><wbr />`[]`<span class="attachedType">GenericGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CGenericGraph%2Cstring%2Cstring"
+    title="`[]`(self: GenericGraph; node: string; key: string): string"><wbr />`[]`<span class="attachedType">GenericGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%3D%2CGenericGraph%2Cstring%2Cstring%2Cstring"
+    title="`[]=`(self: GenericGraph; node: string; key: string; value: string)"><wbr />`[]=`<span class="attachedType">GenericGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CGraph%2CEdge"
+    title="`[]`(self: Graph; edge: Edge): Table[string, string]"><wbr />`[]`<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CDiGraph%2CDiEdge"
+    title="`[]`(self: DiGraph; edge: DiEdge): Table[string, string]"><wbr />`[]`<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CGraph%2CEdge%2Cstring"
+    title="`[]`(self: Graph; edge: Edge; key: string): string"><wbr />`[]`<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%2CDiGraph%2CDiEdge%2Cstring"
+    title="`[]`(self: DiGraph; edge: DiEdge; key: string): string"><wbr />`[]`<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%3D%2CGraph%2CEdge%2Cstring%2Cstring"
+    title="`[]=`(self: Graph; edge: Edge; key: string; value: string)"><wbr />`[]=`<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#%5B%5D%3D%2CDiGraph%2CDiEdge%2Cstring%2Cstring"
+    title="`[]=`(self: DiGraph; edge: DiEdge; key: string; value: string)"><wbr />`[]=`<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#exportDot%2CGraph"
+    title="exportDot(self: Graph): string"><wbr />export<wbr />Dot<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#exportDot%2CDiGraph"
+    title="exportDot(self: DiGraph): string"><wbr />export<wbr />Dot<span class="attachedType">DiGraph</span></a></li>
 
   </ul>
 </li>
 <li>
   <a class="reference reference-toplevel" href="#15" id="65">Iterators</a>
   <ul class="simple simple-toc-section">
-      <li><a class="reference" href="#iterEdges.i,Graph"
-    title="iterEdges(self: Graph): Edge"><wbr />iter<wbr />Edges<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#iterEdges.i,Graph,string"
-    title="iterEdges(self: Graph; nbunch: string): Edge"><wbr />iter<wbr />Edges<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
-  <li><a class="reference" href="#iterNodes.i,Graph"
-    title="iterNodes(self: Graph): string"><wbr />iter<wbr />Nodes<span class="attachedType" style="visibility:hidden">Graph</span></a></li>
+      <li><a class="reference" href="#iterEdges.i%2CGraph%2Cstring"
+    title="iterEdges(self: Graph; node: string): Edge"><wbr />iter<wbr />Edges<span class="attachedType">Graph</span></a></li>
+  <li><a class="reference" href="#iterEdges.i%2CDiGraph%2Cstring"
+    title="iterEdges(self: DiGraph; node: string): DiEdge"><wbr />iter<wbr />Edges<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#iterEdgesIn.i%2CDiGraph%2Cstring"
+    title="iterEdgesIn(self: DiGraph; node: string): DiEdge"><wbr />iter<wbr />Edges<wbr />In<span class="attachedType">DiGraph</span></a></li>
+  <li><a class="reference" href="#iterEdgesOut.i%2CDiGraph%2Cstring"
+    title="iterEdgesOut(self: DiGraph; node: string): DiEdge"><wbr />iter<wbr />Edges<wbr />Out<span class="attachedType">DiGraph</span></a></li>
 
   </ul>
 </li>
@@ -1306,56 +946,106 @@ function main() {
   </div>
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
-  <p class="module-desc"><p>The <cite>nimgraphviz</cite> module is a library for making graphs using <a class="reference external" href="http://www.graphviz.org">GraphViz</a> based on <a class="reference external" href="http://pygraphviz.github.io">PyGraphviz</a>.</p>
+  
+  <p class="module-desc"><p>The <tt class="docutils literal"><span class="pre">nimgraphviz</span></tt> module is a library for making graphs using <a class="reference external" href="http://www.graphviz.org">GraphViz</a> based on <a class="reference external" href="http://pygraphviz.github.io">PyGraphviz</a>.</p>
 <p>To export images, you must have GraphViz installed. Download it here: <a class="reference external" href="https://graphviz.gitlab.io/download">https://graphviz.gitlab.io/download</a></p>
 <p>Here is an example of creating a simple graph:</p>
 <pre class="listing"><span class="Comment"># create a directed graph</span>
-<span class="Keyword">var</span> <span class="Identifier">graph</span> <span class="Operator">=</span> <span class="Identifier">initGraph</span><span class="Punctuation">(</span><span class="Identifier">directed</span><span class="Operator">=</span><span class="Identifier">true</span><span class="Punctuation">)</span>
+<span class="Keyword">let</span> <span class="Identifier">graph</span> <span class="Operator">=</span> <span class="Identifier">newDiGraph</span><span class="Punctuation">(</span><span class="Punctuation">)</span>
 
 <span class="Comment"># set some attributes of the graph:</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">graphAttr</span><span class="Operator">.</span><span class="Identifier">add</span><span class="Punctuation">(</span><span class="StringLit">&quot;fontsize&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;32&quot;</span><span class="Punctuation">)</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">graphAttr</span><span class="Operator">.</span><span class="Identifier">add</span><span class="Punctuation">(</span><span class="StringLit">&quot;label&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;Test Graph&quot;</span><span class="Punctuation">)</span>
+<span class="Identifier">graph</span><span class="Punctuation">[</span><span class="StringLit">&quot;fontsize&quot;</span><span class="Punctuation">]</span> <span class="Operator">=</span> <span class="StringLit">&quot;32&quot;</span>
+<span class="Identifier">graph</span><span class="Punctuation">[</span><span class="StringLit">&quot;label&quot;</span><span class="Punctuation">]</span> <span class="Operator">=</span> <span class="StringLit">&quot;Test Graph&quot;</span>
+<span class="Comment"># (You can also access nodes and edges attributes this way :)</span>
+<span class="Comment"># graph[&quot;a&quot;][&quot;bgcolor&quot;] = &quot;red&quot;</span>
+<span class="Comment"># graph[&quot;a&quot;-&gt;&quot;b&quot;][&quot;arrowhead&quot;] = &quot;diamond&quot;</span>
 
 <span class="Comment"># add edges:</span>
 <span class="Comment"># (if a node does not exist already it will be created automatically)</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;a&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;b&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;a-to-b&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">[</span><span class="Punctuation">(</span><span class="StringLit">&quot;label&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;A to B&quot;</span><span class="Punctuation">)</span><span class="Punctuation">]</span><span class="Punctuation">)</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;c&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;b&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;c-to-b&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">[</span><span class="Punctuation">(</span><span class="StringLit">&quot;style&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;dotted&quot;</span><span class="Punctuation">)</span><span class="Punctuation">]</span><span class="Punctuation">)</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;b&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;a&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;b-to-a&quot;</span><span class="Punctuation">)</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addNode</span><span class="Punctuation">(</span><span class="StringLit">&quot;c&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">[</span><span class="Punctuation">(</span><span class="StringLit">&quot;color&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;blue&quot;</span><span class="Punctuation">)</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;shape&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;box&quot;</span><span class="Punctuation">)</span><span class="Punctuation">,</span>
-                    <span class="Punctuation">(</span><span class="StringLit">&quot;style&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;filled&quot;</span><span class="Punctuation">)</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;fontcolor&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;white&quot;</span><span class="Punctuation">)</span><span class="Punctuation">]</span><span class="Punctuation">)</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addNode</span><span class="Punctuation">(</span><span class="StringLit">&quot;d&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">[</span><span class="Punctuation">(</span><span class="StringLit">&quot;lable&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;node&quot;</span><span class="Punctuation">)</span><span class="Punctuation">]</span><span class="Punctuation">)</span>
+<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;a&quot;</span><span class="Operator">-&gt;</span><span class="StringLit">&quot;b&quot;</span> <span class="Punctuation">(</span><span class="StringLit">&quot;label&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;A to B&quot;</span><span class="Punctuation">)</span><span class="Punctuation">)</span>
+<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;c&quot;</span><span class="Operator">-&gt;</span><span class="StringLit">&quot;b&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;style&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;dotted&quot;</span><span class="Punctuation">)</span><span class="Punctuation">)</span>
+<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;b&quot;</span><span class="Operator">-&gt;</span><span class="StringLit">&quot;a&quot;</span><span class="Punctuation">)</span>
+<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addNode</span><span class="Punctuation">(</span><span class="StringLit">&quot;c&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;color&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;blue&quot;</span><span class="Punctuation">)</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;shape&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;box&quot;</span><span class="Punctuation">)</span><span class="Punctuation">,</span>
+                    <span class="Punctuation">(</span><span class="StringLit">&quot;style&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;filled&quot;</span><span class="Punctuation">)</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;fontcolor&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;white&quot;</span><span class="Punctuation">)</span><span class="Punctuation">)</span>
+<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">addNode</span><span class="Punctuation">(</span><span class="StringLit">&quot;d&quot;</span><span class="Punctuation">,</span> <span class="Punctuation">(</span><span class="StringLit">&quot;label&quot;</span><span class="Punctuation">,</span> <span class="StringLit">&quot;node 'd'&quot;</span><span class="Punctuation">)</span><span class="Punctuation">)</span>
 
 <span class="Comment"># if you want to export the graph in the DOT language,</span>
 <span class="Comment"># you can do it like this:</span>
 <span class="Comment"># echo graph.exportDot()</span>
 
 <span class="Comment"># Export graph as PNG:</span>
-<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">exportImage</span><span class="Punctuation">(</span><span class="StringLit">&quot;test_graph.png&quot;</span><span class="Punctuation">)</span></pre></p>
+<span class="Identifier">graph</span><span class="Operator">.</span><span class="Identifier">exportImage</span><span class="Punctuation">(</span><span class="StringLit">&quot;test_graph.png&quot;</span><span class="Punctuation">)</span>
+
+<span class="Identifier">You</span> <span class="Identifier">can</span> <span class="Identifier">also</span> <span class="Identifier">nest</span> <span class="Identifier">subgraphs</span> <span class="Identifier">indefinitely</span> <span class="Punctuation">:</span>
+<span class="Keyword">let</span> <span class="Identifier">sub</span> <span class="Operator">=</span> <span class="Identifier">newSubGraph</span><span class="Punctuation">(</span><span class="Identifier">graph</span><span class="Punctuation">)</span>
+<span class="Comment"># let subsub = newSubGraph(sub)</span>
+<span class="Identifier">sub</span><span class="Operator">.</span><span class="Identifier">addEdge</span><span class="Punctuation">(</span><span class="StringLit">&quot;x&quot;</span><span class="Operator">-&gt;</span><span class="StringLit">&quot;y&quot;</span><span class="Punctuation">)</span>
+<span class="Comment"># The subgraph is automatically included in the main graph</span>
+<span class="Comment"># when you export it. It can also work standalone.</span></pre></p>
   <div class="section" id="6">
 <h1><a class="toc-backref" href="#6">Imports</a></h1>
 <dl class="item">
-<a class="reference external" href="tables.html">tables</a>, <a class="reference external" href="sequtils.html">sequtils</a>, <a class="reference external" href="strutils.html">strutils</a>, <a class="reference external" href="strformat.html">strformat</a>, <a class="reference external" href="osproc.html">osproc</a>, <a class="reference external" href="streams.html">streams</a>, <a class="reference external" href="sets.html">sets</a>
+<a class="reference external" href="edges.html">edges</a>
 </dl></div>
 <div class="section" id="7">
 <h1><a class="toc-backref" href="#7">Types</a></h1>
 <dl class="item">
-<dt id="Edge"><a name="Edge"></a><pre><span class="Identifier">Edge</span> <span class="Other">=</span> <span class="Keyword">tuple</span><span class="Other">[</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">,</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">]</span></pre></dt>
+<a id="Edge"></a>
+<dt><pre><a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a> <span class="Other">=</span> <span class="Keyword">object</span>
+  <span class="Identifier">a</span><span class="Operator">*</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">string</span>
+</pre></dt>
 <dd>
 
+Represents a non-oriented edge <tt class="docutils literal"><span class="pre">a -- b</span></tt> in DOT syntax.
 
 </dd>
-<dt id="Graph"><a name="Graph"></a><pre><span class="Identifier">Graph</span> <span class="Other">=</span> <span class="Keyword">object</span>
-  <span class="Identifier">name</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">string</span>
-  <span class="Identifier">isDirected</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">bool</span>            <span class="Comment">## Whether or not the graph is directed</span>
+<a id="DiEdge"></a>
+<dt><pre><a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a> <span class="Other">=</span> <span class="Keyword">object</span>
+  <span class="Identifier">a</span><span class="Operator">*</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">string</span>
+</pre></dt>
+<dd>
+
+Represents an oriented edge <tt class="docutils literal"><span class="pre">a -&gt; b</span></tt> in DOT syntax.
+
+</dd>
+<a id="NodeCollection"></a>
+<dt><pre><a href="nimgraphviz.html#NodeCollection"><span class="Identifier">NodeCollection</span></a> <span class="Other">=</span> <span class="Keyword">ref</span> <span class="Keyword">object</span> <span class="Keyword">of</span> <span class="Identifier">RootObj</span>
+  <span class="Identifier">name</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">string</span>                <span class="Comment">## The name of the graph</span>
   <span class="Identifier">graphAttr</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span> <span class="Comment">## A table of key-value pairs</span>
                                  <span class="Comment">## describing the layout and</span>
                                  <span class="Comment">## appearence of the graph</span>
-  <span class="Identifier">edgesTable</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">HashSet</span><span class="Other">[</span><span class="Identifier">Edge</span><span class="Other">]</span><span class="Other">]</span>
-  <span class="Identifier">edgeAttrs</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">Edge</span><span class="Other">,</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span><span class="Other">]</span>
-  <span class="Identifier">nodeAttrs</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span><span class="Other">]</span>
+  <span class="Identifier">nodeAttrs</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span><span class="Other">]</span> <span class="Comment">## A table of all the nodes and their attributes</span>
+  </pre></dt>
+<dd>
+
+Base type for both types of graphs. You should not have to instanciate it directly.
+
+</dd>
+<a id="Graph"></a>
+<dt><pre><a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a> <span class="Other">=</span> <span class="Keyword">ref</span> <span class="Keyword">object</span> <span class="Keyword">of</span> <a href="nimgraphviz.html#NodeCollection"><span class="Identifier">NodeCollection</span></a>
+  <span class="Identifier">subGraphs</span><span class="Other">:</span> <span class="Identifier">seq</span><span class="Other">[</span><a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">]</span>
+  <span class="Identifier">edges</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">,</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span><span class="Other">]</span>
 </pre></dt>
 <dd>
-The name of the graph
+
+This types models a non-oriented graph.
+
+</dd>
+<a id="DiGraph"></a>
+<dt><pre><a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a> <span class="Other">=</span> <span class="Keyword">ref</span> <span class="Keyword">object</span> <span class="Keyword">of</span> <a href="nimgraphviz.html#NodeCollection"><span class="Identifier">NodeCollection</span></a>
+  <span class="Identifier">subGraphs</span><span class="Other">:</span> <span class="Identifier">seq</span><span class="Other">[</span><a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">]</span>
+  <span class="Identifier">edges</span><span class="Operator">*</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">,</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span><span class="Other">]</span>
+</pre></dt>
+<dd>
+
+This type models an oriented graph.
+
+</dd>
+<a id="GenericGraph"></a>
+<dt><pre><a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a> <span class="Other">=</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a> <span class="Keyword">or</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a></pre></dt>
+<dd>
+
+
 
 </dd>
 
@@ -1363,85 +1053,209 @@ The name of the graph
 <div class="section" id="12">
 <h1><a class="toc-backref" href="#12">Procs</a></h1>
 <dl class="item">
-<dt id="setGraphVizPath"><a name="setGraphVizPath,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">setGraphVizPath</span><span class="Other">(</span><span class="Identifier">path</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-sets the directory to search for the GraphViz executable (<tt class="docutils literal"><span class="pre">dot</span></tt>) if it is not in your PATH. should end in a delimiter (&quot;<tt class="docutils literal"><span class="pre">/</span></tt>&quot; or &quot;<tt class="docutils literal"><span class="pre">\</span></tt>&quot;)
-
-</dd>
-<dt id="initGraph"><a name="initGraph,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">initGraph</span><span class="Other">(</span><span class="Identifier">name</span><span class="Other">:</span> <span class="Identifier">string</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">;</span> <span class="Identifier">directed</span> <span class="Other">=</span> <span class="Identifier">false</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Graph</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
+<a id="exportImage,GenericGraph,string,string,string,string"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#exportImage%2CGenericGraph%2Cstring%2Cstring%2Cstring%2Cstring"><span class="Identifier">exportImage</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">fileName</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">layout</span> <span class="Other">=</span> <span class="StringLit">&quot;dot&quot;</span><span class="Other">;</span> <span class="Identifier">format</span> <span class="Other">=</span> <span class="StringLit">&quot;&quot;</span><span class="Other">;</span>
+                <span class="Identifier">exec</span> <span class="Other">=</span> <span class="StringLit">&quot;dot&quot;</span><span class="Other">)</span></pre></dt>
 <dd>
 
-
-</dd>
-<dt id="addEdge"><a name="addEdge,Graph,string,string,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">addEdge</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Keyword">var</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-the same as <tt class="docutils literal"><span class="pre">addEdge*(self: var Graph, a, b: string, key: string, attrs: openArray[(string, string)])</span></tt> but without attributes and <tt class="docutils literal"><span class="pre">key</span></tt> is optional
-
-</dd>
-<dt id="addEdge"><a name="addEdge,Graph,string,string,string,openArray[]"></a><pre><span class="Keyword">proc</span> <span class="Identifier">addEdge</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Keyword">var</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
-            <span class="Identifier">attrs</span><span class="Other">:</span> <span class="Identifier">openArray</span><span class="Other">[</span><span class="Other">(</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">]</span><span class="Other">)</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-<p>Adds an edge to the graph connecting nodes <tt class="docutils literal"><span class="pre">a</span></tt> and <tt class="docutils literal"><span class="pre">b</span></tt>. If the nodes don't already exist in the graph, they will be created</p>
-<p><tt class="docutils literal"><span class="pre">key</span></tt> is an identifier for the edge. It can be useful when you want to have multiple edges between the same two nodes</p>
-<p><tt class="docutils literal"><span class="pre">attrs</span></tt> is a set of key-value pairs specifying styling attributes for the edge. You can call <tt class="docutils literal"><span class="pre">addEdge</span></tt> again multiple times with the same nodes and key and different attrs to add new attributes</p>
-<p>For example: .. code-block:: nim</p>
-<blockquote><p>var graph = initGraph() graph.addEdge(&quot;a&quot;, &quot;b&quot;, nil, [(&quot;color&quot;, &quot;blue&quot;)]) graph.addEdge(&quot;a&quot;, &quot;b&quot;, nil, [(&quot;style&quot;, &quot;dotted&quot;)])</p></blockquote>
-<p>will create a graph with a single dotted, blue edge</p>
-
-
-</dd>
-<dt id="edges"><a name="edges,Graph"></a><pre><span class="Keyword">proc</span> <span class="Identifier">edges</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">seq</span><span class="Other">[</span><span class="Identifier">Edge</span><span class="Other">]</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-A list of all the edges in the graph (An edge is a three-tuple of two nodes and the edge key)
-
-</dd>
-<dt id="edges"><a name="edges,Graph,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">edges</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">nbunch</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">seq</span><span class="Other">[</span><span class="Identifier">Edge</span><span class="Other">]</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-A list of all the edges in the graph that are adjacent to the given node (coming in or out) (An edge is a three-tuple of two nodes and the edge key)
-
-</dd>
-<dt id="addNode"><a name="addNode,Graph,string,openArray[]"></a><pre><span class="Keyword">proc</span> <span class="Identifier">addNode</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Keyword">var</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">attrs</span><span class="Other">:</span> <span class="Identifier">openArray</span><span class="Other">[</span><span class="Other">(</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">]</span><span class="Other">)</span> <span class="Other pragmabegin">{.</span><div class="pragma">
-    <span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-<p>Adds a node to the graph. <tt class="docutils literal"><span class="pre">key</span></tt> is the name of the node, used to refer to it when creating edges, etc. It will be used as the label unless another label is given</p>
-<p><tt class="docutils literal"><span class="pre">attrs</span></tt> is a set of key-value pairs describing layout attributes for the node. You can call <tt class="docutils literal"><span class="pre">addNode()</span></tt> for an existing node to update its attributes</p>
-
-
-</dd>
-<dt id="nodes"><a name="nodes,Graph"></a><pre><span class="Keyword">proc</span> <span class="Identifier">nodes</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">seq</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">]</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-Returns a <tt class="docutils literal"><span class="pre">seq</span></tt> of the nodes in the graph
-
-</dd>
-<dt id="degree"><a name="degree,Graph,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">degree</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">int</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-The number of edges adjacent to the given node (in or out)
-
-</dd>
-<dt id="inDegree"><a name="inDegree,Graph,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">inDegree</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">int</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-The number of edges into the given node If the graph is directed, it is the same as <tt class="docutils literal"><span class="pre">degree()</span></tt>
-
-</dd>
-<dt id="outDegree"><a name="outDegree,Graph,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">outDegree</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">int</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-The number of edges out of the given node If the graph is directed, it is the same as <tt class="docutils literal"><span class="pre">degree()</span></tt>
-
-</dd>
-<dt id="exportDot"><a name="exportDot,Graph"></a><pre><span class="Keyword">proc</span> <span class="Identifier">exportDot</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
-Returns a string describing the graph GraphViz's <a class="reference external" href="https://en.wikipedia.org/wiki/DOT_(graph_description_language)">dot language</a>.
-
-</dd>
-<dt id="exportImage"><a name="exportImage,Graph,string,string,string"></a><pre><span class="Keyword">proc</span> <span class="Identifier">exportImage</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">fileName</span><span class="Other">:</span> <span class="Identifier">string</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">;</span> <span class="Identifier">layout</span> <span class="Other">=</span> <span class="StringLit">&quot;dot&quot;</span><span class="Other">;</span> <span class="Identifier">format</span> <span class="Other">=</span> <span class="StringLit">&quot;png&quot;</span><span class="Other">)</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
-    <span class="Identifier">SystemError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">GraphVizException</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span>
-    <span class="Identifier">ExecIOEffect</span><span class="Other">,</span> <span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">RootEffect</span><span class="Other">,</span> <span class="Identifier">ReadEnvEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
-<dd>
 <p>Exports the graph as an image file.</p>
-<p><tt class="docutils literal"><span class="pre">filename</span></tt> - the name of the file to export to. Should include &quot;.png&quot; or the appropriate file extension. If none is given, it will default to the name of the graph. If that is <tt class="docutils literal"><span class="pre">nil</span></tt>, it will default to <tt class="docutils literal"><span class="pre">graph.png</span></tt></p>
+<p><tt class="docutils literal"><span class="pre">filename</span></tt> - the name of the file to export to. Should include &quot;.png&quot; or the appropriate file extension.</p>
 <p><tt class="docutils literal"><span class="pre">layout</span></tt> - which of the GraphViz layout engines to use. Default is <tt class="docutils literal"><span class="pre">dot</span></tt>. Can be one of: <tt class="docutils literal"><span class="pre">dot</span></tt>, <tt class="docutils literal"><span class="pre">neato</span></tt>, <tt class="docutils literal"><span class="pre">fdp</span></tt>, <tt class="docutils literal"><span class="pre">sfdp</span></tt>, <tt class="docutils literal"><span class="pre">twopi</span></tt>, <tt class="docutils literal"><span class="pre">circo</span></tt> (or others if you have them installed).</p>
-<p><tt class="docutils literal"><span class="pre">format</span></tt> - the output format to export to. The default is <tt class="docutils literal"><span class="pre">png</span></tt>. You can specify more details with <tt class="docutils literal"><span class="pre">&quot;{format}:{rendering engine}:{library}&quot;</span></tt>. (See <a class="reference external" href="http://www.graphviz.org/doc/info/command.html">GV command-line docs</a> for more details)</p>
+<p><tt class="docutils literal"><span class="pre">format</span></tt> - the output format to export to. The default is <tt class="docutils literal"><span class="pre">svg</span></tt>. If not specified, it is deduced from the file name. You can specify more details with <tt class="docutils literal"><span class="pre">&quot;{format}:{rendering engine}:{library}&quot;</span></tt>. (See <a class="reference external" href="http://www.graphviz.org/doc/info/command.html">GV command-line docs</a> for more details)</p>
+<p><tt class="docutils literal"><span class="pre">exec</span></tt> - path to the <tt class="docutils literal"><span class="pre">dot</span></tt> command; use this when <tt class="docutils literal"><span class="pre">dot</span></tt> is not in your PATH</p>
 
+
+</dd>
+
+</dl></div>
+<div class="section" id="13">
+<h1><a class="toc-backref" href="#13">Funcs</a></h1>
+<dl class="item">
+<a id="==,Edge,Edge"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%3D%3D%2CEdge%2CEdge"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">edge1</span><span class="Other">,</span> <span class="Identifier">edge2</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">bool</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+N.B.: <tt class="docutils literal"><span class="pre">a--b</span></tt> == <tt class="docutils literal"><span class="pre">b--a</span></tt>
+
+</dd>
+<a id="==,DiEdge,DiEdge"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%3D%3D%2CDiEdge%2CDiEdge"><span class="Identifier">`==`</span></a><span class="Other">(</span><span class="Identifier">edge1</span><span class="Other">,</span> <span class="Identifier">edge2</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">bool</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+N.B.: <tt class="docutils literal"><span class="pre">a-&gt;b</span></tt> != <tt class="docutils literal"><span class="pre">b-&gt;a</span></tt>
+
+</dd>
+<a id="hash,Edge"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#hash%2CEdge"><span class="Identifier">hash</span></a><span class="Other">(</span><span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Hash</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="hash,DiEdge"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#hash%2CDiEdge"><span class="Identifier">hash</span></a><span class="Other">(</span><span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Hash</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="--,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#--%2Cstring%2Cstring"><span class="Identifier">`--`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Convenience syntax for Edge(...)
+
+</dd>
+<a id="->,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#-%3E%2Cstring%2Cstring"><span class="Identifier">`-&gt;`</span></a><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Convenience syntax for DiEdge(...)
+
+</dd>
+<a id="newGraph"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#newGraph"><span class="Identifier">newGraph</span></a><span class="Other">(</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="newDiGraph"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#newDiGraph"><span class="Identifier">newDiGraph</span></a><span class="Other">(</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="newSubGraph,Graph"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#newSubGraph%2CGraph"><span class="Identifier">newSubGraph</span></a><span class="Other">(</span><span class="Identifier">parent</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Returns a new graph, attached to its parent as subgraph. Some graphviz engines have a specific behaviour when the name of the subgraph begins with &quot;cluster&quot; -- see the official website. Note that the subgraphs are full graphs themselves: you can treat them as standalone objects (e.g. when exporting images) Note: All subgraphs must keep their parent's &quot;orientedness&quot;
+
+</dd>
+<a id="newSubGraph,DiGraph"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#newSubGraph%2CDiGraph"><span class="Identifier">newSubGraph</span></a><span class="Other">(</span><span class="Identifier">parent</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Returns a new digraph, attached to its parent as subgraph. Some graphviz engines have a specific behaviour when the name of the subgraph begins with &quot;cluster&quot; -- see the official website. Note that the subgraphs are full graphs themselves: you can treat them as standalone objects (e.g. when exporting images) Note: All subgraphs must keep their parent's &quot;orientedness&quot;
+
+</dd>
+<a id="addEdge,Graph,Edge,varargs[]"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#addEdge%2CGraph%2CEdge%2Cvarargs%5B%5D"><span class="Identifier">addEdge</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">;</span> <span class="Identifier">attr</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Other">(</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">]</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma">
+    <span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Add an edge to the graph. Optional attributes may be specified as a serie of (key, value) tuples.
+
+</dd>
+<a id="addEdge,DiGraph,DiEdge,varargs[]"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#addEdge%2CDiGraph%2CDiEdge%2Cvarargs%5B%5D"><span class="Identifier">addEdge</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">;</span> <span class="Identifier">attr</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Other">(</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">]</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma">
+    <span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Add an edge to the graph. Optional attributes may be specified as a serie of (key, value) tuples.
+
+</dd>
+<a id="addNode,GenericGraph,string,varargs[]"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#addNode%2CGenericGraph%2Cstring%2Cvarargs%5B%5D"><span class="Identifier">addNode</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">attr</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Other">(</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">]</span><span class="Other">)</span></pre></dt>
+<dd>
+
+Add a node to the graph. Optional attributes may be specified as a serie of (key, value) tuples. Note that you don't need to add a node manually if it appears in an edge.
+
+</dd>
+<a id="[],GenericGraph,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CGenericGraph%2Cstring"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">gAttr</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
+<dd>
+
+Shortcut to access graph attributes
+
+</dd>
+<a id="[]=,GenericGraph,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%3D%2CGenericGraph%2Cstring%2Cstring"><span class="Identifier">`[]=`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">gAttr</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">value</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span></pre></dt>
+<dd>
+
+Shortcut to set graph attributes
+
+</dd>
+<a id="[],GenericGraph,string_2"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CGenericGraph%2Cstring_2"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span></pre></dt>
+<dd>
+
+Shortcut to access node attributes Returns the attribute table for the given node. Throws the relevant exception from Table when the node does not exist.
+
+</dd>
+<a id="[],GenericGraph,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CGenericGraph%2Cstring%2Cstring"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span></pre></dt>
+<dd>
+
+Shortcut to access node attributes Returns the attribute value for the given node, given key. Throws the relevant exception from Table when the node does not exist.
+
+</dd>
+<a id="[]=,GenericGraph,string,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%3D%2CGenericGraph%2Cstring%2Cstring%2Cstring"><span class="Identifier">`[]=`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#GenericGraph"><span class="Identifier">GenericGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">value</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span></pre></dt>
+<dd>
+
+Shortcut to edit node attributes. If the node hasn't got a table yet, it gets one beforehand.
+
+</dd>
+<a id="[],Graph,Edge"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CGraph%2CEdge"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="[],DiGraph,DiEdge"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CDiGraph%2CDiEdge"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Table</span><span class="Other">[</span><span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">string</span><span class="Other">]</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span>
+    <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="[],Graph,Edge,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CGraph%2CEdge%2Cstring"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="[],DiGraph,DiEdge,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%2CDiGraph%2CDiEdge%2Cstring"><span class="Identifier">`[]`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="[]=,Graph,Edge,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%3D%2CGraph%2CEdge%2Cstring%2Cstring"><span class="Identifier">`[]=`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">value</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span>
+    <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Shortcut to edit edge attributes. If the edge doesn't exist in the graph yet, it is created beforehand.
+
+</dd>
+<a id="[]=,DiGraph,DiEdge,string,string"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#%5B%5D%3D%2CDiGraph%2CDiEdge%2Cstring%2Cstring"><span class="Identifier">`[]=`</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">edge</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a><span class="Other">;</span> <span class="Identifier">key</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">value</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span>
+    <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Shortcut to edit edge attributes. If the edge doesn't exist in the graph yet, it is created beforehand.
+
+</dd>
+<a id="exportDot,Graph"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#exportDot%2CGraph"><span class="Identifier">exportDot</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Returns the dot script corresponding to the graph, including subgraphs.
+
+</dd>
+<a id="exportDot,DiGraph"></a>
+<dt><pre><span class="Keyword">func</span> <a href="#exportDot%2CDiGraph"><span class="Identifier">exportDot</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Returns the dot script corresponding to the graph, including subgraphs.
 
 </dd>
 
@@ -1449,19 +1263,32 @@ Returns a string describing the graph GraphViz's <a class="reference external" h
 <div class="section" id="15">
 <h1><a class="toc-backref" href="#15">Iterators</a></h1>
 <dl class="item">
-<dt id="iterEdges"><a name="iterEdges.i,Graph"></a><pre><span class="Keyword">iterator</span> <span class="Identifier">iterEdges</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Edge</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
+<a id="iterEdges.i,Graph,string"></a>
+<dt><pre><span class="Keyword">iterator</span> <a href="#iterEdges.i%2CGraph%2Cstring"><span class="Identifier">iterEdges</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#Graph"><span class="Identifier">Graph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#Edge"><span class="Identifier">Edge</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
 <dd>
-iterator over all the edges in the graph. An edge is a three-tuple of two nodes and the edge key
+
+Iterate over all the edges adjacent to a given node
 
 </dd>
-<dt id="iterEdges"><a name="iterEdges.i,Graph,string"></a><pre><span class="Keyword">iterator</span> <span class="Identifier">iterEdges</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">;</span> <span class="Identifier">nbunch</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Edge</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">KeyError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
+<a id="iterEdges.i,DiGraph,string"></a>
+<dt><pre><span class="Keyword">iterator</span> <a href="#iterEdges.i%2CDiGraph%2Cstring"><span class="Identifier">iterEdges</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
 <dd>
-iterator over all the edges in the graph that are adjacent to the given node (coming in or out). Yields three-tuples of two nodes and the edge key
+
+Iterate over all the edges adjacent to a given node
 
 </dd>
-<dt id="iterNodes"><a name="iterNodes.i,Graph"></a><pre><span class="Keyword">iterator</span> <span class="Identifier">iterNodes</span><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <span class="Identifier">Graph</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">string</span> <span class="Other pragmabegin">{.</span><div class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></div><span class="Other pragmaend">.}</span></pre></dt>
+<a id="iterEdgesIn.i,DiGraph,string"></a>
+<dt><pre><span class="Keyword">iterator</span> <a href="#iterEdgesIn.i%2CDiGraph%2Cstring"><span class="Identifier">iterEdgesIn</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
 <dd>
-Iterates over all of the nodes in the graph
+
+Oriented version: yields only inbound edges
+
+</dd>
+<a id="iterEdgesOut.i,DiGraph,string"></a>
+<dt><pre><span class="Keyword">iterator</span> <a href="#iterEdgesOut.i%2CDiGraph%2Cstring"><span class="Identifier">iterEdgesOut</span></a><span class="Other">(</span><span class="Identifier">self</span><span class="Other">:</span> <a href="nimgraphviz.html#DiGraph"><span class="Identifier">DiGraph</span></a><span class="Other">;</span> <span class="Identifier">node</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">)</span><span class="Other">:</span> <a href="nimgraphviz.html#DiEdge"><span class="Identifier">DiEdge</span></a> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Oriented version: yields only outbound edges
 
 </dd>
 
@@ -1474,7 +1301,7 @@ Iterates over all of the nodes in the graph
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small>Made with Nim. Generated: 2018-06-11 10:05:42 UTC</small>
+        <small>Made with Nim. Generated: 2021-09-30 19:16:46 UTC</small>
       </div>
     </div>
   </div>

--- a/nimgraphviz.nimble
+++ b/nimgraphviz.nimble
@@ -1,7 +1,7 @@
 # Package
 
-version       = "0.2.0"
-author        = "Quinn Freedman"
+version       = "0.3.0"
+author        = "Quinn Freedman, Alexis Masson"
 description   = "Nim bindings for the GraphViz tool and the DOT graph language"
 license       = "MIT"
 srcDir        = "src"

--- a/src/nimgraphviz.nim
+++ b/src/nimgraphviz.nim
@@ -1,5 +1,5 @@
 # nimgraphviz
-# Copyright Quinn
+# Copyright Quinn, Aveheuzed
 # Nim bindings for the GraphViz tool and the DOT graph language
 
 ## The `nimgraphviz` module is a library for making graphs using
@@ -13,20 +13,23 @@
 ##
 ## .. code-block:: nim
 ##    # create a directed graph
-##    var graph = newGraph(directed=true)
+##    let graph = newDiGraph()
 ##
 ##    # set some attributes of the graph:
-##    graph.graphAttr.add("fontsize", "32")
-##    graph.graphAttr.add("label", "Test Graph")
+##    graph["fontsize"] = "32"
+##    graph["label"] = "Test Graph"
+##    # (You can also access nodes and edges attributes this way :)
+##    # graph["a"]["bgcolor"] = "red"
+##    # graph["a"->"b"]["arrowhead"] = "diamond"
 ##
 ##    # add edges:
 ##    # (if a node does not exist already it will be created automatically)
-##    graph.addEdge("a", "b", "a-to-b", [("label", "A to B")])
-##    graph.addEdge("c", "b", "c-to-b", [("style", "dotted")])
-##    graph.addEdge("b", "a", "b-to-a")
-##    graph.addNode("c", [("color", "blue"), ("shape", "box"),
-##                        ("style", "filled"), ("fontcolor", "white")])
-##    graph.addNode("d", [("lable", "node")])
+##    graph.addEdge("a"->"b" ("label", "A to B"))
+##    graph.addEdge("c"->"b", ("style", "dotted"))
+##    graph.addEdge("b"->"a")
+##    graph.addNode("c", ("color", "blue"), ("shape", "box"),
+##                        ("style", "filled"), ("fontcolor", "white"))
+##    graph.addNode("d", ("label", "node 'd'"))
 ##
 ##    # if you want to export the graph in the DOT language,
 ##    # you can do it like this:
@@ -34,426 +37,23 @@
 ##
 ##    # Export graph as PNG:
 ##    graph.exportImage("test_graph.png")
+##
+##    You can also nest subgraphs indefinitely :
+##    let sub = newSubGraph(graph)
+##    # let subsub = newSubGraph(sub)
+##    sub.addEdge("x"->"y")
+##    # The subgraph is automatically included in the main graph
+##    # when you export it. It can also work standalone.
 
-import
-  tables,
-  sequtils,
-  strutils,
-  strformat,
-  os,
-  osproc,
-  streams,
-  sets
-
-export tables
+include "nimgraphviz/private/edges", "nimgraphviz/private/graphs"
 
 
-type GraphVizException = object of Exception
+when isMainModule :
+  let main = newGraph()
+  let sub = newSubGraph(main)
 
-type
-  Edge* = tuple
-    a, b, key: string
+  main.addEdge("a"--"b")
+  sub.addEdge("b"--"c")
+  sub.name = "cluster_whatever"
 
-  GraphKind = enum
-    gkGraph, gkSubgraph
-
-  Graph* = ref object
-    name*: string    ## The name of the graph
-    isDirected*: bool  ## Whether or not the graph is directed
-    graphAttr*: Table[string, string]  ## A table of key-value pairs
-                       ## describing the layout and
-                       ## appearence of the graph
-    subGraphs: seq[Graph] ## a graph may have multiple sub graphs
-    edgesTable: Table[string, HashSet[Edge]]
-    edgeAttrs: Table[Edge, Table[string, string]]
-    nodeAttrs: Table[string, Table[string, string]]
-    case kind: GraphKind
-    of gkGraph: discard
-    of gkSubgraph:
-      id: int
-      clusterName*: string
-
-proc newGraph*(name: string = "",
-               directed = false,
-               kind: GraphKind = gkGraph): Graph =
-  result = Graph(
-    name: name,
-    isDirected: directed,
-    graphAttr: initTable[string, string](),
-    edgesTable: initTable[string, HashSet[Edge]](),
-    edgeAttrs: initTable[Edge, Table[string, string]](),
-    nodeAttrs: initTable[string, Table[string, string]](),
-    kind: kind
-  )
-
-proc initGraph*(name: string = "", directed = false): Graph {.deprecated: "`initGraph` is " &
-  " deprecated in favor of `newGraph` as `Graph` is a `ref object`.".} =
-  result = newGraph(name, directed)
-
-proc ensureSafeName(key:string) {.inline.} =
-  if not key.validIdentifier() :
-    raise newException(GraphVizException, "Edge and node names must be valid (C-wise) identifiers")
-
-proc addNode*(self: var Graph, key: string, attrs: openArray[(string, string)])
-
-proc newSubgraph*(g: var Graph, name: string): Graph =
-  name.ensureSafeName()
-  result = newGraph(name = name, directed = true, kind = gkSubgraph)
-  result.graphAttr["style"] = "filled"
-  result.graphAttr["label"] = name # ""
-  result.addNode(name, [("style", "plaintext")])
-  result.id = g.subGraphs.len
-  result.clusterName = "cluster_" & $result.id
-  g.subGraphs.add result
-
-proc addGraph*(self: var Graph, g: Graph) =
-  ## adds the given graph `g` as a subgraph to `self`
-  ## Note: this should not be required if the subgraph was created
-  ## using `newSubgraph`!
-  self.subGraphs.add g
-
-proc addEdge*(self: var Graph, a, b: string, key: string = "") =
-  ## the same as ``addEdge*(self: var Graph, a, b: string, key: string, attrs: openArray[(string, string)])``
-  ## but without attributes and ``key`` is optional
-  a.ensureSafeName()
-  b.ensureSafeName()
-
-  let key = if key.len == 0: &"{a}-to-{b}" else: key
-  let edge = (a, b, key)
-  if not (a in self.nodeAttrs):
-    self.nodeAttrs[a] = initTable[string, string](4)
-  if not (b in self.nodeAttrs):
-    self.nodeAttrs[b] = initTable[string, string](4)
-
-  if a in self.edgesTable:
-    self.edgesTable[a].incl(edge)
-  else:
-    self.edgesTable[a] = [edge].toHashSet
-
-  if b in self.edgesTable:
-    self.edgesTable[b].incl(edge)
-  else:
-    self.edgesTable[b] = [edge].toHashSet
-
-
-proc addEdge*(self: var Graph, a, b: string, key = "",
-        attrs: openArray[(string, string)]) =
-  ## Adds an edge to the graph connecting nodes ``a`` and ``b``.
-  ## If the nodes don't already exist in the graph, they will be
-  ## created
-  ##
-  ## ``key`` is an identifier for the edge. It can be useful when
-  ## you want to have multiple edges between the same two nodes
-  ##
-  ## ``attrs`` is a set of key-value pairs specifying styling
-  ## attributes for the edge. You can call ``addEdge`` again
-  ## multiple times with the same nodes and key and different
-  ## attrs to add new attributes
-  ##
-  ## For example:
-  ## .. code-block:: nim
-  ##   var graph = initGraph()
-  ##   graph.addEdge("a", "b", nil, [("color", "blue")])
-  ##   graph.addEdge("a", "b", nil, [("style", "dotted")])
-  ##
-  ## will create a graph with a single dotted, blue edge
-
-  # -- unnecessary, done in the other addEdge()
-  # a.ensureSafeName()
-  # b.ensureSafeName()
-  let key = if key.len == 0: &"{a}-to-{b}" else: key
-  self.addEdge(a, b, key)
-
-  let edge = (a, b, key)
-  if edge in self.edgeAttrs:
-    for pair in attrs:
-      let (k, v) = pair
-      self.edgeAttrs[edge][k] = v
-  else:
-    self.edgeAttrs[edge] = attrs.toTable()
-
-iterator iterEdges*(self: Graph): Edge =
-  ## iterator over all the edges in the graph.
-  ## An edge is a three-tuple of two nodes and the edge key
-  for key in self.edgesTable.keys:
-    for edge in self.edgesTable[key]:
-      if edge.a == key:
-        yield edge
-
-iterator iterEdges*(self: Graph, nbunch: string): Edge =
-  ## iterator over all the edges in the graph that are adjacent
-  ## to the given node (coming in or out).
-  ## Yields three-tuples of two nodes and the edge key
-  if nbunch in self.edgesTable:
-    for edge in self.edgesTable[nbunch]:
-      yield edge
-
-template seqFromIterImpl[T](iter: untyped) =
-  result = newSeq[T]()
-  for it in iter:
-    result.add(it)
-
-proc edges*(self: Graph): seq[Edge] =
-  ## A list of all the edges in the graph
-  ## (An edge is a three-tuple of two nodes and the edge key)
-  seqFromIterImpl[Edge](self.iterEdges)
-
-proc edges*(self: Graph, nbunch: string): seq[Edge] =
-  ## A list of all the edges in the graph that are adjacent to
-  ## the given node (coming in or out)
-  ## (An edge is a three-tuple of two nodes and the edge key)
-  seqFromIterImpl[Edge](self.iterEdges(nbunch))
-
-proc addNode*(self: var Graph, key: string,
-        attrs: openArray[(string, string)]) =
-  ## Adds a node to the graph.
-  ## ``key`` is the name of the node, used to refer to it
-  ## when creating edges, etc. It will be used as the label
-  ## unless another label is given
-  ##
-  ## ``attrs`` is a set of key-value pairs describing layout
-  ## attributes for the node. You can call ``addNode()`` for
-  ## an existing node to update its attributes
-  key.ensureSafeName()
-  if key in self.nodeAttrs:
-    for pair in attrs:
-      let (k, v) = pair
-      self.nodeAttrs[key][k] = v
-  else:
-    self.nodeAttrs[key] = attrs.toTable
-
-iterator iterNodes*(self: Graph): string =
-  ## Iterates over all of the nodes in the graph
-  for node in self.nodeAttrs.keys:
-    yield node
-
-proc nodes*(self: Graph): seq[string] =
-  ## Returns a ``seq`` of the nodes in the graph
-  seqFromIterImpl[string](self.iterNodes)
-
-proc degree*(self: Graph, node: string): int =
-  ## The number of edges adjacent to the given node (in or out)
-  if node in self.edgesTable:
-    self.edgesTable[node].len
-  else:
-    -1
-
-proc inDegree*(self: Graph, node: string): int =
-  ## The number of edges into the given node
-  ## If the graph is directed, it is the same as ``degree()``
-  if not self.isDirected:
-    return self.degree(node)
-
-  if node in self.edgesTable:
-    for edge in self.edgesTable[node]:
-      if edge.b == node:
-        result += 1
-  else:
-    result = -1
-
-proc outDegree*(self: Graph, node: string): int =
-  ## The number of edges out of the given node
-  ## If the graph is directed, it is the same as ``degree()``
-  if not self.isDirected:
-    return self.degree(node)
-
-  if node in self.edgesTable:
-    for edge in self.edgesTable[node]:
-      if edge.a == node:
-        result += 1
-  else:
-    result = -1
-
-proc attrList(attr: Table[string, string]): seq[string] =
-  result = newSeq[string]()
-  for pair in attr.pairs:
-    let (key, value) = pair
-    result.add(&"{key}=\"{value}\"")
-
-proc exportAttrList(attr: Table[string, string]): string =
-  let pairs = attrList(attr)
-  if pairs.len == 0:
-    return ""
-  return "[" & pairs.join(", ") & "]"
-
-
-proc exportAttributes(g: Graph): string =
-  result &= "/*\n" &
-        " * Graph attributes:\n" &
-        " */\n"
-  result &= attrList(g.graphAttr)
-      .map(proc(a: string): string = &"{a};\n")
-      .join()
-  result &= "\n\n"
-
-proc exportNodes(g: Graph): string =
-  result &= "/*\n" &
-        " * Nodes:\n" &
-        " */\n"
-  for pair in g.nodeAttrs.pairs:
-    let (node, attrs) = pair
-    result &= &"{node} {exportAttrList(attrs)};\n"
-  result &= "\n\n"
-
-proc exportEdges(g: Graph): string =
-  result &= "/*\n" &
-        " * Edges:\n" &
-        " */\n"
-
-  let edgeSymbol =
-    if g.isDirected: "->"
-    else: "--"
-
-  for edge in g.iterEdges():
-    if len(edge.key) != 0:
-      result &= &"//key={edge.key}\n"
-    let attrs =
-      if edge in g.edgeAttrs:
-        exportAttrList(g.edgeAttrs[edge])
-      else: ""
-    result &= &"{edge.a} {edgeSymbol} {edge.b} {attrs};\n"
-
-proc exportSubGraphs(g: Graph): string =
-  for i, sub in g.subGraphs:
-    doAssert sub.kind == gkSubgraph
-    result &= &"subgraph {sub.clusterName} " & "{\n"
-    result &= sub.exportAttributes()
-    result &= sub.exportNodes()
-    result &= sub.exportEdges()
-    result &= "}\n\n"
-
-proc exportDot*(self: Graph): string =
-  ## Returns a string describing the graph GraphViz's
-  ## `dot language <https://en.wikipedia.org/wiki/DOT_(graph_description_language)>`_.
-
-  let graphType =
-    if self.isDirected: "digraph"
-    else: "graph"
-
-  let name = self.name
-
-  result = &"strict {graphType} {name} {{\n"
-  result &= self.exportSubGraphs()
-
-  result &= self.exportAttributes()
-  result &= self.exportNodes()
-  result &= self.exportEdges()
-
-  result &= "}\n"
-
-proc exportImage*(self: Graph, fileName="",
-          layout="dot", format="", exec="dot") =
-  ## Exports the graph as an image file.
-  ##
-  ## ``filename`` - the name of the file to export to. Should include ".png"
-  ## or the appropriate file extension. If none is given, it will default to
-  ## the name of the graph. If that is ``nil``, it will default to
-  ## ``graph.svg``.
-  ##
-  ## ``layout`` - which of the GraphViz layout engines to use. Default is
-  ## ``dot``. Can be one of: ``dot``, ``neato``, ``fdp``, ``sfdp``, ``twopi``,
-  ## ``circo`` (or others if you have them installed).
-  ##
-  ## ``format`` - the output format to export to. The default is ``svg``.
-  ## If not specified, it is deduced from the file name.
-  ## You can specify more details with
-  ## ``"{format}:{rendering engine}:{library}"``.
-  ## (See `GV command-line docs <http://www.graphviz.org/doc/info/command.html>`_
-  ## for more details)
-  ##
-  ## ``exec`` - path to the ``dot`` command; use this when ``dot`` is not in
-  ## your PATH
-
-  # This blocks determines the output file name and its content type
-  # fileName has precedence over self.name
-  # The content type is deduced from the file name unless explicitely specified.
-  var dir, name, ext :string
-  if len(fileName) != 0:
-    (dir, name, ext) = splitFile(fileName)
-    if len(dir) == 0 :
-      dir = "." # current dir
-  elif len(self.name) != 0:
-    dir = "." # current dir
-    name = self.name
-    ext = "." & format
-  else :
-    dir = "."
-    name = "graph" # default name : "graph"
-    ext = "." & format
-
-  if ext == "." :
-    ext = ".svg" # default format : SVG
-
-  let actual_format =
-    if format != "" :
-       format
-    else :
-      ext[1..^1] # remove the '.' in first position
-  let file = &"{dir}/{name}{ext}"
-
-  let text = self.exportDot()
-  let args = [
-    &"-K{layout}",
-    &"-o{file}",
-    &"-T{actual_format}",
-    "-q"
-  ]
-  let process =
-    try :
-      startProcess(exec, args=args, options={poUsePath})
-    except OSError :
-      # "command not found", but I think the default message is explicit enough
-      # the try/except block is just there to show where the error can arise
-      raise
-  let stdin = process.inputStream
-  let stdout = process.outputStream
-  stdin.write(text)
-  stdin.close()
-  let errcode = process.waitForExit()
-  let errormsg = stdout.readAll()
-  process.close()
-  if errcode != 0:
-    raise newException(GraphVizException, errormsg)
-
-
-
-
-when isMainModule:
-  var graph = newGraph(directed=true)
-  graph.graphAttr["fontsize"] = "32"
-  graph.graphAttr["label"] = "Test Graph"
-  graph.addEdge("a", "b", "a-to-b", [("label", "A to B")])
-  graph.addEdge("c", "b", "c-to-b", [("style", "dotted")])
-  graph.addEdge("b", "a", "b-to-a")
-  graph.addNode("c", [("color", "blue"), ("shape", "box"),
-            ("style", "filled"), ("fontcolor", "white")])
-  graph.addNode("&d", [("lable", "node")])
-
-  assert graph.nodes.len == 4
-  assert graph.edges.len == 3
-  assert graph.edges("a").len == 2
-  assert graph.edges("d").len == 0
-  assert "a" in graph.nodes
-  assert "b" in graph.nodes
-  assert "c" in graph.nodes
-  assert "d" in graph.nodes
-  assert ("a", "b", "a-to-b") in graph.edges("a")
-
-
-  echo "Example DOT graph:"
-  echo graph.exportDot()
-  echo "\nExporting graph as PNG..."
-  # set the location of the `dot` program if not in your path:
-  # setGraphVizPath(r"C:\Program Files (x86)\Graphviz2.38\bin\")
-
-  graph.exportImage(format="png", exec="echo")
-  # graph.exportImage("test_graph.json")
-  # graph.exportImage()
-  # graph.exportImage("test_graph.png", format="svg")
-  #[
-  Files these calls create (in order) :
-  - graph.png, containing PNG data
-  # - test_graph.json, containing JSON data
-  # - graph.svg, containing SVG data
-  # - test_graph.png, __containing SVG data__ (yes it's legit)
-  ]#
+  echo main.exportDot()

--- a/src/nimgraphviz.nim
+++ b/src/nimgraphviz.nim
@@ -49,11 +49,27 @@ include "nimgraphviz/private/edges", "nimgraphviz/private/graphs"
 
 
 when isMainModule :
-  let main = newGraph()
-  let sub = newSubGraph(main)
+  let main = newGraph() # create a graph (strict, but not oriented)
+  let sub = newSubGraph(main) # the graph can have subgraph
+  # the subgraph can have subgraphs too!
 
-  main.addEdge("a"--"b")
+  # adding an edge, along with attributes
+  main.addEdge("a"--"b", ("label", "A to B"))
+
+  # attributes can also be added afterwards
   sub.addEdge("b"--"c")
-  sub.name = "cluster_whatever"
+  sub["b"--"c"]["style"] = "dotted"
 
+  # similar features are available for nodes
+  main["d"]["label"] = "This node stands alone"
+
+  # subgraphs whose name begin in "cluster" have a special meaning in DOT.
+  sub.name = "cluster_whatever"
+  sub["bgcolor"] = "grey" # hey, graph attributes can be set as well!
+
+  # if you want to export the graph in the DOT language,
+  # you can do it like this:
   echo main.exportDot()
+
+  # Export graph as PNG:
+  graph.exportImage("test_graph.png")

--- a/src/nimgraphviz/private/edges.nim
+++ b/src/nimgraphviz/private/edges.nim
@@ -1,0 +1,39 @@
+import hashes
+
+type
+  Edge* = object
+    ## Represents a non-oriented edge
+    ## `a -- b` in DOT syntax.
+    a*, b*: string
+  DiEdge* = object
+    ## Represents an oriented edge
+    ## `a -> b` in DOT syntax.
+    a*, b*: string
+
+func `==`*(edge1, edge2: Edge):bool =
+  ## N.B.: `a--b` == `b--a`
+  return
+    (edge1.a == edge2.a and edge1.b == edge2.b) or
+    (edge1.a == edge2.b and edge1.b == edge2.a)
+
+func `==`*(edge1, edge2:DiEdge):bool =
+  ## N.B.: `a->b` != `b->a`
+  return
+    (edge1.a == edge2.a and edge1.b == edge2.b)
+
+func hash*(edge:Edge): Hash =
+  # use xor instead of !& to ensure Edge(a,b) == Edge(b, a)
+  result = hash(edge.a) xor hash(edge.b)
+  result = !$result
+
+func hash*(edge:DiEdge): Hash =
+  result = hash(edge.a) !& hash(edge.b)
+  result = !$result
+
+func `--`*(a, b:string):Edge =
+  ## Convenience syntax for Edge(...)
+  result = Edge(a:a, b:b)
+
+func `->`*(a,b:string):DiEdge =
+  ## Convenience syntax for DiEdge(...)
+  result = DiEdge(a:a, b:b)

--- a/src/nimgraphviz/private/graphs.nim
+++ b/src/nimgraphviz/private/graphs.nim
@@ -1,0 +1,304 @@
+import os
+import osproc
+import streams
+import strformat
+import strutils
+
+import "./edges"
+
+import tables
+export tables
+
+
+type
+  NodeCollection* = ref object of RootObj
+    ## Base type for both types of graphs.
+    ## You should not have to instanciate it directly.
+    name*: string    ## The name of the graph
+    graphAttr*: Table[string, string]  ## A table of key-value pairs
+                       ## describing the layout and
+                       ## appearence of the graph
+    nodeAttrs*: Table[string, Table[string, string]] ## A table of all the nodes and their attributes
+
+  Graph* = ref object of NodeCollection
+    ## This types models a non-oriented graph.
+    subGraphs: seq[Graph] # a graph may have multiple sub graphs
+    edges*: Table[Edge, Table[string, string]]
+
+  DiGraph* = ref object of NodeCollection
+    ## This type models an oriented graph.
+    subGraphs: seq[DiGraph] # a graph may have multiple sub graphs
+    edges*: Table[DiEdge, Table[string, string]]
+
+  GenericGraph* = Graph or DiGraph
+
+
+func newGraph*(): Graph =
+  result = Graph(
+    graphAttr: initTable[string, string](),
+    nodeAttrs: initTable[string, Table[string, string]](),
+    subGraphs: newSeq[Graph](),
+    edges: initTable[Edge, Table[string, string]](),
+  )
+
+func newDiGraph*(): DiGraph =
+  result = DiGraph(
+    graphAttr: initTable[string, string](),
+    nodeAttrs: initTable[string, Table[string, string]](),
+    subGraphs: newSeq[DiGraph](),
+    edges: initTable[DiEdge, Table[string, string]](),
+  )
+
+#TODO: find a way to properly merge the two implementations ? (generics)
+func newSubGraph*(parent: Graph): Graph =
+  ## Returns a new graph, attached to its parent as subgraph.
+  ## Some graphviz engines have a specific behaviour when the name of the
+  ## subgraph begins with "cluster" -- see the official website.
+  ## Note that the subgraphs are full graphs themselves: you can treat them
+  ## as standalone objects (e.g. when exporting images)
+  ## Note: All subgraphs must keep their parent's "orientedness"
+  result = newGraph()
+  parent.subGraphs.add(result)
+func newSubGraph*(parent: DiGraph): DiGraph =
+  ## Returns a new digraph, attached to its parent as subgraph.
+  ## Some graphviz engines have a specific behaviour when the name of the
+  ## subgraph begins with "cluster" -- see the official website.
+  ## Note that the subgraphs are full graphs themselves: you can treat them
+  ## as standalone objects (e.g. when exporting images)
+  ## Note: All subgraphs must keep their parent's "orientedness"
+  result = newDiGraph()
+  parent.subGraphs.add(result)
+
+# TODO: find a way to properly merge the two implementations ? (generics)
+func addEdge*(self: Graph, edge: Edge, attr: varargs[(string, string)]) =
+  ## Add an edge to the graph. Optional attributes may be specified as a serie
+  ## of (key, value) tuples.
+  if not self.edges.hasKey(edge) :
+    self.edges[edge] = initTable[string, string]()
+
+  for (k,v) in attr:
+    self.edges[edge][k] = v
+func addEdge*(self: DiGraph, edge: DiEdge, attr: varargs[(string, string)]) =
+  ## Add an edge to the graph. Optional attributes may be specified as a serie
+  ## of (key, value) tuples.
+  if not self.edges.hasKey(edge) :
+    self.edges[edge] = initTable[string, string]()
+
+  for (k,v) in attr:
+    self.edges[edge][k] = v
+
+func addNode*(self: GenericGraph, node: string, attr: varargs[(string, string)]) =
+  ## Add a node to the graph. Optional attributes may be specified as a serie
+  ## of (key, value) tuples.
+  ## Note that you don't need to add a node manually if it appears in an edge.
+  if not self.nodeAttrs.hasKey(node) :
+    self.nodeAttrs[node] = initTable[string, string]()
+
+  for (k,v) in attr:
+    self.nodeAttrs[node][k] = v
+
+
+func `[]`*(self: GenericGraph, gAttr: string): string =
+  ## Shortcut to access graph attributes
+  self.graphAttr[gAttr]
+func `[]=`*(self: GenericGraph, gAttr: string, value: string) =
+  ## Shortcut to set graph attributes
+  self.graphAttr[gAttr] = value
+
+func `[]`*(self: GenericGraph, node: string): Table[string, string] =
+  ## Shortcut to access node attributes
+  ## Returns the attribute table for the given node.
+  ## Throws the relevant exception from Table when the node does not exist.
+  self.nodeAttrs[node]
+func `[]`*(self: GenericGraph, node: string, key: string): string =
+  ## Shortcut to access node attributes
+  ## Returns the attribute value for the given node, given key.
+  ## Throws the relevant exception from Table when the node does not exist.
+  self.nodeAttrs[node][key]
+func `[]=`*(self: GenericGraph, node: string, key: string, value: string) =
+  ## Shortcut to edit node attributes.
+  ## If the node hasn't got a table yet, it gets one beforehand.
+  self.addNode(node)
+  self.nodeAttrs[node][key] = value
+
+
+# TODO: find a way to properly merge the two implementations ? (generics)
+func `[]`*(self: Graph, edge: Edge): Table[string, string] =
+  ## Shortcut to access edge attributes
+  ## Returns the attribute table for the given edge.
+  ## Throws the relevant exception from Table when the edge does not exist.
+  self.edges[edge]
+func `[]`*(self: DiGraph, edge: DiEdge): Table[string, string] =
+  ## Shortcut to access edge attributes
+  ## Returns the attribute table for the given edge.
+  ## Throws the relevant exception from Table when the edge does not exist.
+  self.edges[edge]
+func `[]`*(self: Graph, edge: Edge, key: string): string =
+  ## Shortcut to access edge attributes
+  ## Returns the attribute value for the given edge, given key.
+  ## Throws the relevant exception from Table when the edge does not exist.
+  self.edges[edge][key]
+func `[]`*(self: DiGraph, edge: DiEdge, key: string): string =
+  ## Shortcut to access edge attributes
+  ## Returns the attribute value for the given edge, given key.
+  ## Throws the relevant exception from Table when the edge does not exist.
+  self.edges[edge][key]
+func `[]=`*(self: Graph, edge: Edge, key: string, value: string) =
+  ## Shortcut to edit edge attributes.
+  ## If the edge doesn't exist in the graph yet, it is created beforehand.
+  self.addEdge(edge)
+  self.edges[edge][key] = value
+func `[]=`*(self: DiGraph, edge: DiEdge, key: string, value: string) =
+  ## Shortcut to edit edge attributes.
+  ## If the edge doesn't exist in the graph yet, it is created beforehand.
+  self.addEdge(edge)
+  self.edges[edge][key] = value
+
+
+
+# TODO: find a way to properly merge the two implementations ? (generics)
+iterator iterEdges*(self: Graph, node: string): Edge =
+  ## Iterate over all the edges adjacent to a given node
+  for edge in self.edges.keys() :
+    if edge.a == node or edge.b == node:
+      yield edge
+iterator iterEdges*(self: DiGraph, node: string): DiEdge =
+  ## Iterate over all the edges adjacent to a given node
+  for edge in self.edges.keys() :
+    if edge.a == node or edge.b == node:
+      yield edge
+
+iterator iterEdgesIn*(self: DiGraph, node: string): DiEdge =
+  ## Oriented version: yields only inbound edges
+  for edge in self.edges.keys() :
+    if edge.b == node:
+      yield edge
+iterator iterEdgesOut*(self: DiGraph, node: string): DiEdge =
+  ## Oriented version: yields only outbound edges
+  for edge in self.edges.keys() :
+    if edge.a == node:
+      yield edge
+
+
+func exportIdentifier(identifier:string): string =
+  if identifier.validIdentifier() :
+    return identifier
+
+  # if needs be, escape '"' and surround in quotes (do not replace '\' !!)
+  return "\"" & identifier.replace("\"", "\\\"") & "\""
+
+func `$`(edge: Edge): string =
+  exportIdentifier(edge.a) & " -- " & exportIdentifier(edge.b)
+func `$`(edge: DiEdge): string =
+  exportIdentifier(edge.a) & " -> " & exportIdentifier(edge.b)
+
+func exportSubDot(self: GenericGraph): string # forward declaration
+
+func tableToAttributes(tbl: Table[string, string]): seq[string] =
+  for (key, value) in tbl.pairs() :
+    result.add exportIdentifier(key) & "=" & exportIdentifier(value)
+
+func exportAttributes(self: GenericGraph): string =
+  result = tableToAttributes(self.graphAttr).join(";\n")
+  if len(result) > 0 :
+    result &= "\n"
+
+func exportNodes(self: GenericGraph): string =
+  for (node, tbl) in self.nodeAttrs.pairs() :
+    result &= exportIdentifier(node)
+    if tbl.len > 0:
+      result &= " ["
+      result &= tableToAttributes(tbl).join(", ")
+      result &= "]"
+    result &= ";\n"
+
+func exportEdges(self: GenericGraph): string =
+  for (edge, tbl) in self.edges.pairs() :
+    result &= $edge
+    if tbl.len > 0:
+      result &= " ["
+      result &= tableToAttributes(tbl).join(", ")
+      result &= "]"
+    result &= ";\n"
+
+func buildBody(self: GenericGraph): string =
+  result = "{\n"
+  for sub in self.subGraphs :
+    result &= exportSubDot(sub)
+  result &= self.exportAttributes()
+  result &= self.exportNodes()
+  result &= self.exportEdges()
+  result &= "}\n"
+
+func exportSubDot(self: GenericGraph): string =
+  result = "subgraph " & exportIdentifier(self.name) & " " & self.buildBody()
+
+func exportDot*(self: Graph): string =
+  ## Returns the dot script corresponding to the graph, including subgraphs.
+  result = "strict graph " & exportIdentifier(self.name) & " " & self.buildBody()
+func exportDot*(self: DiGraph): string =
+  ## Returns the dot script corresponding to the graph, including subgraphs.
+  result = "strict digraph " & exportIdentifier(self.name) & " " & self.buildBody()
+
+proc exportImage*(self: GenericGraph, fileName: string,
+          layout="dot", format="", exec="dot") =
+  ## Exports the graph as an image file.
+  ##
+  ## ``filename`` - the name of the file to export to. Should include ".png"
+  ## or the appropriate file extension.
+  ##
+  ## ``layout`` - which of the GraphViz layout engines to use. Default is
+  ## ``dot``. Can be one of: ``dot``, ``neato``, ``fdp``, ``sfdp``, ``twopi``,
+  ## ``circo`` (or others if you have them installed).
+  ##
+  ## ``format`` - the output format to export to. The default is ``svg``.
+  ## If not specified, it is deduced from the file name.
+  ## You can specify more details with
+  ## ``"{format}:{rendering engine}:{library}"``.
+  ## (See `GV command-line docs <http://www.graphviz.org/doc/info/command.html>`_
+  ## for more details)
+  ##
+  ## ``exec`` - path to the ``dot`` command; use this when ``dot`` is not in
+  ## your PATH
+
+  # This blocks determines the output file name and its content type
+  # fileName has precedence over self.name
+  # The content type is deduced from the file name unless explicitely specified.
+
+  var (dir, name, ext) = splitFile(fileName)
+  if len(dir) == 0 :
+    dir = "." # current dir
+
+  if ext == "." or ext == "":
+    ext = ".svg" # default format : SVG
+
+  let actual_format =
+    if format != "" :
+       format
+    else :
+      ext[1..^1] # remove the '.' in first position
+  let file = &"{dir}/{name}{ext}"
+
+  let text = self.exportDot()
+  let args = [
+    &"-K{layout}",
+    &"-o{file}",
+    &"-T{actual_format}",
+    "-q"
+  ]
+  let process =
+    try :
+      startProcess(exec, args=args, options={poUsePath})
+    except OSError :
+      # "command not found", but I think the default message is explicit enough
+      # the try/except block is just there to show where the error can arise
+      raise
+  let stdin = process.inputStream
+  let stderr = process.errorStream
+  stdin.write(text)
+  stdin.close()
+  let errcode = process.waitForExit()
+  let errormsg = stderr.readAll()
+  process.close()
+  if errcode != 0:
+    raise newException(OSError, fmt"[errcode {errcode}] " & errormsg)


### PR DESCRIPTION
I took the liberty of changing the types involved in this lib to enhance security (automatic type checking) : graphs and digraphs may not be mixed, and the current implementation (with an enum) was kinda unsound.
This allowed me to implement the arbitrary nesting of subgraphs in a simpler, safer fashion (I need that feature for a side-project of mine).
I also added a bunch of syntactic sugar to represent edges (as suggested by @Vindaar in #3), and allow an easier manipulation of graph/node/edge attributes.

I (obviously) also bumped up the version number, since most of the API changed, and rebuilt the docs; they were severly out-of-date. I think I did it right, but I could use your review; I'm not yet used to managing Nim packages.

Given all that, I thought I deserved to be officially added to the contributors of the project (you may revert this specific change if it bothers you, I would then maintain my own library independently). Maybe @Vindaar deserves this too, I'll let you two discuss it.

* Split the code
* Used proper type checking to prevent mixing directed and non-directed graphs and edges
* added syntax for the two kind of edges
* added convenience syntax to access/mutate the different kinds of 
attributes
* `var` is not needed anymore anywhere